### PR TITLE
Hotfix Linux multithreading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@
 **/BufferOut
 /build*
 .flatpak*
+.cache
 
 !enhancedassets/*
 

--- a/config_linux.ini
+++ b/config_linux.ini
@@ -1,0 +1,35 @@
+[debug]
+
+[main]
+gameFolder = NETHERW ; Main game content folder (after install). Path is relative to .exe 
+cdFolder = CD_Files ; Main game cd content folder (after install). Path is relative to .exe
+
+
+[skips]
+skipintro = true
+
+[sound]
+hqsound = true ; sound is transfered from 11025,8bit,mono to 44000,16bit,stereo
+oggmusic = true ; using AWE32 record of MIDI music, for this function is hqsound auto enabled
+oggmusicFolder = music-ogg ; directory with music, you can rewrite with own music too. Path is relative to .exe
+oggmusicalternative = true ; use original and alternative sound tracks
+fixspeedsound = false ; set true when sounds play double speed
+
+[graphics]
+windowResWidth = 1920 ; Window resolution, cannot be lower than gameRes
+windowResHeight = 1080 ;
+gameResWidth = 800 ; In Game resolution. If using software render keep this low
+gameResHeight = 600 ;
+useEnhancedGraphics = false ; if set to true, bigGraphicsFolder must be set as well
+bigGraphicsFolder = biggraphics ; directory with 128x128 textures(upscaled by AI).  Path is relative to .exe
+maintainAspectRatio = true ; If set to false, whole window will be used for menu screen etc... stretching content
+sky = true ;
+reflections = true ;
+dynamicLighting = true ;
+multiThreadedRender = false ; If set to false or deleted, multi-threading will not be used in render.
+numberOfRenderThreads = 3 ; Valid range 1-7. Depends on the number of available cores (Press 'T' to change in game). 
+assignToSpecificCores = false ; When set to true, threads will be assigned to a specifc core (as many as supported).
+
+[game]
+speed = 30 ; speed game, millisecond between frames (1000/FPS)
+animspeed = 100 ; speed videos, millisecond between frames (1000/FPS)

--- a/remc2/CMakeLists.txt
+++ b/remc2/CMakeLists.txt
@@ -154,7 +154,8 @@ install(
 )
 install(
     FILES 
-    ${CMAKE_SOURCE_DIR}/config.ini
+    ${CMAKE_SOURCE_DIR}/config_linux.ini
+    RENAME config.ini
     DESTINATION bin
 )
 install(


### PR DESCRIPTION
Use a custom config.ini on Linux in order to disable multithreaded rendering by default.
This makes the game run until we have a proper fix for multithreaded rendering.