### PR TITLE
Set preprocessor flag _DEBUG in Linux debug build

### DIFF
--- a/remc2/CMakeLists.txt
+++ b/remc2/CMakeLists.txt
@@ -192,6 +192,9 @@ if (UNIX)
     )
     target_link_directories(${PROJECT_NAME} PUBLIC
     )
+    target_compile_definitions(${PROJECT_NAME} PUBLIC
+        "$<$<CONFIG:DEBUG>:_DEBUG>"
+    )
 endif ()
 
 


### PR DESCRIPTION
Just a minor change to CMake to set _DEBUG on Linux, too.
One effect is that the FPS counter becomes visible.