### PR TITLE
Fix timing on Linux and main menu animations

### DIFF
--- a/remc2/portability/port_time.cpp
+++ b/remc2/portability/port_time.cpp
@@ -13,7 +13,7 @@ void mydelay(int milliseconds) {
 
 };
 
-long mygethundredths() {
+unsigned long mygethundredths() {
 #ifdef WIN32
 	return clock() / (CLOCKS_PER_SEC/100);
 #else
@@ -23,7 +23,7 @@ long mygethundredths() {
 #endif
 };
 
-long mygetthousandths() {
+unsigned long mygetthousandths() {
 #ifdef WIN32
 	return clock() / (CLOCKS_PER_SEC/1000);
 #else
@@ -33,7 +33,7 @@ long mygetthousandths() {
 #endif
 };
 
-long mygetsecond() {
+unsigned long mygetsecond() {
 #ifdef WIN32
 	return clock();
 #else

--- a/remc2/portability/port_time.cpp
+++ b/remc2/portability/port_time.cpp
@@ -1,5 +1,9 @@
 #include "port_time.h"
 
+#ifndef WIN32
+#include <sys/time.h>
+#endif
+
 void mydelay(int milliseconds) {
 #ifdef WIN32
 	Sleep(milliseconds);
@@ -10,15 +14,33 @@ void mydelay(int milliseconds) {
 };
 
 long mygethundredths() {
-	return clock()/ (CLOCKS_PER_SEC/100);
+#ifdef WIN32
+	return clock() / (CLOCKS_PER_SEC/100);
+#else
+	struct timeval timecheck;
+	gettimeofday(&timecheck, NULL);
+    return ((long)timecheck.tv_sec * 1000 + (long)timecheck.tv_usec / 1000) / 10;
+#endif
 };
 
 long mygetthousandths() {
-	return clock() / (CLOCKS_PER_SEC / 1000);
+#ifdef WIN32
+	return clock() / (CLOCKS_PER_SEC/1000);
+#else
+	struct timeval timecheck;
+	gettimeofday(&timecheck, NULL);
+    return ((long)timecheck.tv_sec * 1000 + (long)timecheck.tv_usec / 1000);
+#endif
 };
 
 long mygetsecond() {
+#ifdef WIN32
 	return clock();
+#else
+	struct timeval timecheck;
+	gettimeofday(&timecheck, NULL);
+    return ((long)timecheck.tv_sec * 1000 + (long)timecheck.tv_usec / 1000) / 1000;
+#endif
 };
 
 double clockToMilliseconds(clock_t ticks) {

--- a/remc2/portability/port_time.h
+++ b/remc2/portability/port_time.h
@@ -13,9 +13,9 @@
 #endif // win32
 
 void mydelay(int timems);
-long mygethundredths();
-long mygetthousandths();
-long mygetsecond();
+unsigned long mygethundredths();
+unsigned long mygetthousandths();
+unsigned long mygetsecond();
 double clockToMilliseconds(clock_t ticks);
 
 #endif //PORT_TIME

--- a/remc2/sub_main.cpp
+++ b/remc2/sub_main.cpp
@@ -1023,7 +1023,7 @@ int /*__fastcall*/ nullsub_1(x_DWORD) { stub_fix_it(); return 0; }; // weak
 int sub_8E0D0() { stub_fix_it(); return 0; }; // weak
 void sub_8F4B0(HMDIDRIVER user) { stub_fix_it(); }; // weak
 int dword_1820E0 = 0;
-long clock_value()
+unsigned long clock_value()
 {
 	return mygethundredths();
 	//return clock()*0.1;
@@ -1044,7 +1044,7 @@ long clock_value()
 	//intdos(&v1, &v1); //fix it
 	return 100 * (v6 + 60 * (60 * v4 + v3)) + v5;*/
 }
-long _clock()
+unsigned long _clock()
 {
 	return clock_value();
 	/*unsigned int v0; // eax
@@ -1054,7 +1054,7 @@ long _clock()
 		v0 += 8640000;
 	return v0 - dword_1820E0;*/
 }
-long /*__fastcall*/ j___clock() {
+unsigned long /*__fastcall*/ j___clock() {
 	return _clock();
 }; // weak
 void sub_99830(HMDIDRIVER  /*user*/) { stub_fix_it(); }; // weak
@@ -2710,7 +2710,7 @@ void sub_90E07_VGA_set_video_mode_640x480_and_Palette(TColor* Palette);
 void sub_90E07_VGA_set_video_mode_alt_and_Palette(TColor* Palette);
 int sub_90EA0(int a1, char* a2);
 void sub_986E0();
-long j___clock(); // weak
+unsigned long j___clock(); // weak
 void sub_98790(unsigned __int16 a1, unsigned __int8 a2);
 signed int sub_98C48_open_nwrite_close(char* file, uint8_t* buffer, uint32_t count);
 size_t sub_98CAA_write(FILE* a1, uint8_t* a2, uint32_t a3);
@@ -5238,10 +5238,10 @@ TColor str_BYTE_E1711[2][18] = {{//players Palette colors is halfed
 }; // weak//2b2711
 
 type_str_unk_E1748 unk_E1748x[5] = { // menu fire animation positions and sprites
-	{0,17, 159, 1, 1,8},
-	{0,531,156, 9, 9,16},
-	{0,154,308, 17,17,25},
-	{0,226,308, 26,26,34},
+	{0,17, 159, 1, 1,8},   // left fire
+	{0,531,156, 9, 9,16},  // right fire
+	{0,152,308, 17,17,25}, // left incense stick
+	{0,481,307, 26,26,34}, // right incense stick
 	{0,0,0,0,0,0}
 };
 //unk_E1784x[3] // removed - referenced from menu animations but never in any code path
@@ -80550,40 +80550,26 @@ void sub_7AA70_load_and_decompres_dat_file(char* path, uint8_t* filebuffer, int 
 //----- (0007AB00) --------------------------------------------------------
 void sub_7AB00_draw_menu_animations()//25bb00
 {
-	int v5; // eax
-	int v6; // edi
-	int iy;
-	int v10; // [esp+0h] [ebp-4h]
-
+	unsigned long now = j___clock();
 	type_str_unk_E1748* a3x = unk_E1748x;
 
-	int ii = 0;
-	while (a3x[ii].word_4) // fire animation
+	// animate fire and incense stick animation
+	for (int ii = 0; a3x[ii].PosX_4; ii++)
 	{
-		v5 = j___clock();
-		v6 = v5;
-		v10 = v5;
-		sub_2BB40_draw_bitmap(a3x[ii].word_4, a3x[ii].word_6, xy_DWORD_17DED4_spritestr[a3x[ii].word_8]);
-		if ((v6 - a3x[ii].dword_0) >> 2 >= 1)
+		sub_2BB40_draw_bitmap(a3x[ii].PosX_4, a3x[ii].PosY_6, xy_DWORD_17DED4_spritestr[a3x[ii].ActSprite_8]);
+		if ((now - a3x[ii].LastTimeRendered_0) >> 2 >= 1)
 		{
-			//a2 = a3x[ii].word_8 + 1;
-			a3x[ii].word_8++;
-			//v7 = a3x[ii].byte_11;
-			//a3[4] = a2;
-			if (a3x[ii].byte_11 < a3x[ii].word_8)
-				a3x[ii].word_8 = a3x[ii].byte_10;
-			//a1 = v10;
-			a3x[ii].dword_0 = v10;
+			a3x[ii].ActSprite_8++;
+			if (a3x[ii].LastSprite_11 < a3x[ii].ActSprite_8)
+				a3x[ii].ActSprite_8 = a3x[ii].FirstSprite_10;
+			a3x[ii].LastTimeRendered_0 = now;
 		}
-		ii++;
-		//a3 += 6;
 	}
-	//for (i = off_E1BAC; *((int32_t*)(i + 10)); i += 44)
-	for (iy = 0; (str_E1BAC[iy].xmin_10<<16) + str_E1BAC[iy].ymin_12; iy++)
+	// draw selected main menu item
+	for (int iy = 0; (str_E1BAC[iy].xmin_10<<16) + str_E1BAC[iy].ymin_12; iy++)
 	{
 		if (str_E1BAC[iy].canSelect_23 && str_E1BAC[iy].gold_color_24)
 		{
-			//v4 = i;
 			sub_2BB40_draw_bitmap(str_E1BAC[iy].xmin_10, str_E1BAC[iy].ymin_12, xy_DWORD_17DED4_spritestr[str_E1BAC[iy].byte_21]);
 		}
 	}

--- a/remc2/sub_main.cpp
+++ b/remc2/sub_main.cpp
@@ -2479,7 +2479,6 @@ signed int sub_79E10(char* a1, char a2);
 //char sub_7A060_get_mouse_and_keyboard_events();
 void sub_7A110_load_hscreen(char a1, char a2);
 void sub_7AA70_load_and_decompres_dat_file(char* a1, uint8_t* a2, int a3, int a4);
-// int (**sub_7AB00_draw_menu_animations(__int16 a1, int a2, signed __int16 *a3, unsigned __int8 a4))(int);
 void sub_7AC00_load_and_set_graphics_and_Palette();
 int sub_7ADE0(char a1);
 //bool sub_7B200_in_region(int16_t* a1, int16_t testx, int16_t testy);
@@ -5238,19 +5237,14 @@ TColor str_BYTE_E1711[2][18] = {{//players Palette colors is halfed
 {0x00,0x00,0x00}}//27-8
 }; // weak//2b2711
 
-type_str_unk_E1748 unk_E1748x[5] = {//some in animations
+type_str_unk_E1748 unk_E1748x[5] = { // menu fire animation positions and sprites
 	{0,17, 159, 1, 1,8},
 	{0,531,156, 9, 9,16},
 	{0,154,308, 17,17,25},
 	{0,226,308, 26,26,34},
 	{0,0,0,0,0,0}
 };
-
-type_str_unk_E1748 unk_E1784x[3] = {
-	{0,299, 306, 1, 1,8},
-	{0,348, 118, 9, 9,16},
-	{0,0,0,0,0,0}
-};
+//unk_E1784x[3] // removed - referenced from menu animations but never in any code path
 
 Type_SoundEvent_E17CC str_E17CC_0[0x32] = {//anim events
 {0x0000,0x45,0x00000004},
@@ -78234,7 +78228,7 @@ void /*__fastcall*/ sub_76FA0_main_menu(/*int a1, */int  /*a2*/, uint16_t a3x)//
 			/*v19 = */sub_7C120_draw_bitmap_640(185, 232, xy_DWORD_17DED4_spritestr[66]);//adress 25827a
 			//ax,ebx,a3
 			//6038,100,4?
-			/*v21 = */sub_7AB00_draw_menu_animations(/*v19,*/ /*v20,*/ /*(int16_t*)a3x,*/ 4u);//25bb00
+			sub_7AB00_draw_menu_animations();//25bb00
 			if (sub_7B250_draw_and_serve(/*(int)v21, v22*/))//25c250
 			{
 				v12 = x_DWORD_17DE38str.x_DWORD_17DEE6_mouse_positiony;
@@ -80554,34 +80548,18 @@ void sub_7AA70_load_and_decompres_dat_file(char* path, uint8_t* filebuffer, int 
 // 17DEE0: using guessed type int x_DWORD_17DEE0_filedesc;
 
 //----- (0007AB00) --------------------------------------------------------
-void sub_7AB00_draw_menu_animations(/*__int16 a1,*/ /*int a2,*/ /*type_str_unk_E1748* a3,*/ unsigned __int8 a4)//25bb00
+void sub_7AB00_draw_menu_animations()//25bb00
 {
-	//uint8_t* v4; // esi
 	int v5; // eax
 	int v6; // edi
-	//signed __int16 v7; // ax
-	//uint8_t* i; // ebx
 	int iy;
 	int v10; // [esp+0h] [ebp-4h]
 
-	//HIBYTE(a1) = a4;//04
-	//v4 = 0;
-	type_str_unk_E1748* a3x = 0;
-	if (a4 == 4u)
-	{
-		a3x = unk_E1748x;
-	}
-	else if (a4 == 6u)
-	{
-		a3x = unk_E1784x;
-	}
+	type_str_unk_E1748* a3x = unk_E1748x;
+
 	int ii = 0;
-	while (a3x[ii].word_4)//fair animation
+	while (a3x[ii].word_4) // fire animation
 	{
-		/*
-		43d1be
-		43d1f4 9c 213
-		*/
 		v5 = j___clock();
 		v6 = v5;
 		v10 = v5;
@@ -80600,16 +80578,13 @@ void sub_7AB00_draw_menu_animations(/*__int16 a1,*/ /*int a2,*/ /*type_str_unk_E
 		ii++;
 		//a3 += 6;
 	}
-	if (a4 == 4)//draw gold selected buttons
+	//for (i = off_E1BAC; *((int32_t*)(i + 10)); i += 44)
+	for (iy = 0; (str_E1BAC[iy].xmin_10<<16) + str_E1BAC[iy].ymin_12; iy++)
 	{
-		//for (i = off_E1BAC; *((int32_t*)(i + 10)); i += 44)
-		for (iy = 0; (str_E1BAC[iy].xmin_10<<16) + str_E1BAC[iy].ymin_12; iy++)
+		if (str_E1BAC[iy].canSelect_23 && str_E1BAC[iy].gold_color_24)
 		{
-			if (str_E1BAC[iy].canSelect_23 && str_E1BAC[iy].gold_color_24)
-			{
-				//v4 = i;
-				sub_2BB40_draw_bitmap(str_E1BAC[iy].xmin_10, str_E1BAC[iy].ymin_12, xy_DWORD_17DED4_spritestr[str_E1BAC[iy].byte_21]);
-			}
+			//v4 = i;
+			sub_2BB40_draw_bitmap(str_E1BAC[iy].xmin_10, str_E1BAC[iy].ymin_12, xy_DWORD_17DED4_spritestr[str_E1BAC[iy].byte_21]);
 		}
 	}
 }
@@ -81518,7 +81493,7 @@ void WaitToConnect_7C230()//25d230
 		CopyScreen((void*)x_DWORD_E9C38_smalltit, (void*)pdwScreenBuffer_351628, 640, 480);
 	}
 	sub_7C120_draw_bitmap_640(185, 232, xy_DWORD_17DED4_spritestr[66]);
-	sub_7AB00_draw_menu_animations(4u);
+	sub_7AB00_draw_menu_animations();
 	if (sub_7BF20_draw_scroll_dialog(&str_WORD_E1F70))
 	{
 		x_WORD_E131A = 1;

--- a/remc2/sub_main.h
+++ b/remc2/sub_main.h
@@ -221,12 +221,12 @@ typedef struct {//lenght 24
 subx_BYTE_E7EE0x;
 
 typedef struct {
-	long    LastTimeRendered_0; // time of last render
+	unsigned long LastTimeRendered_0; // time of last render
 	int16_t PosX_4;  // posx
 	int16_t PosY_6;  // posy
 	int16_t ActSprite_8;  // act sprite
-	int8_t  FirstSprite_10;  // first sprite
-	int8_t  LastSprite_11;  // last sprite
+	int8_t FirstSprite_10;  // first sprite
+	int8_t LastSprite_11;  // last sprite
 }type_str_unk_E1748;
 
 typedef struct {//lenght 30

--- a/remc2/sub_main.h
+++ b/remc2/sub_main.h
@@ -221,12 +221,12 @@ typedef struct {//lenght 24
 subx_BYTE_E7EE0x;
 
 typedef struct {
-	long   dword_0; // time of last render
-	int16_t word_4;  // posx
-	int16_t word_6;  // posy
-	int16_t word_8;  // act sprite
-	int8_t byte_10;  // first sprite
-	int8_t byte_11;  // last sprite
+	long    LastTimeRendered_0; // time of last render
+	int16_t PosX_4;  // posx
+	int16_t PosY_6;  // posy
+	int16_t ActSprite_8;  // act sprite
+	int8_t  FirstSprite_10;  // first sprite
+	int8_t  LastSprite_11;  // last sprite
 }type_str_unk_E1748;
 
 typedef struct {//lenght 30

--- a/remc2/sub_main.h
+++ b/remc2/sub_main.h
@@ -221,12 +221,12 @@ typedef struct {//lenght 24
 subx_BYTE_E7EE0x;
 
 typedef struct {
-	int32_t dword_0;
-	int16_t word_4;
-	int16_t word_6;
-	int16_t word_8;//act sprite
-	int8_t byte_10;//first sprite
-	int8_t byte_11;//last sprite
+	long   dword_0; // time of last render
+	int16_t word_4;  // posx
+	int16_t word_6;  // posy
+	int16_t word_8;  // act sprite
+	int8_t byte_10;  // first sprite
+	int8_t byte_11;  // last sprite
 }type_str_unk_E1748;
 
 typedef struct {//lenght 30
@@ -479,7 +479,7 @@ signed int NetworkAddName_74767(/*signed __int16* a1,*/ myNCB* a2x, char* a3);
 //unsigned char __readgsx_BYTE(unsigned long Offset);
 //unsigned short __readgsx_WORD(unsigned long Offset);
 //int /*__fastcall*/ _wcpp_1_unwind_leave__131(x_DWORD);// weak
-void sub_7AB00_draw_menu_animations(/*__int16 a1,*/ /*int a2,*/ /*type_str_unk_E1748* a3,*/ unsigned __int8 a4);
+void sub_7AB00_draw_menu_animations();
 int sub_7F6A0(int a1, int a2, __int16 a3, __int16 a4, char* a5, int8_t* a6, unsigned __int8 a7);
 void sub_81CA0(int a1, int a2, __int16 a3, __int16 a4, type_x_BYTE_E25ED_db_str* a5);
 signed int sub_7E5A0_pre_draw(int a1, int a2, __int16 a3, __int16 a4, uint8_t* a5, __int16 a6, __int16 a7);


### PR DESCRIPTION
This PR fixes https://github.com/thobbsinteractive/magic-carpet-2-hd/issues/115 and some other issues:
- using accurate wall clock on Linux for correct fps in videos and level selection
- fixes main menu animation speed
- fixes position of animated incense sticks in main menu
- cleans up main menu animation code
- removes unused data and code paths