### PR TITLE
memimages path parameter for regression tests 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,11 +2,28 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "(gdb) Launch",
+            "name": "Game",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Debug/inst/bin/remc2",
-            "args": [],
+            "args": [
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/Debug/inst/bin",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb"
+        },
+        {
+            "name": "Regression Tests",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Debug/inst/bin/remc2",
+            "args": [
+                "reglevel", "0",
+                "--mode_test_regressions_game"
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/build/Debug/inst/bin",
             "environment": [],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,8 @@
             "program": "${workspaceFolder}/build/Debug/inst/bin/remc2",
             "args": [
                 "reglevel", "0",
-                "--mode_test_regressions_game"
+                "--mode_test_regressions_game",
+                "--memimages_path", "${workspaceFolder}/build/Debug/inst/memimages/"
             ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/build/Debug/inst/bin",

--- a/remc2/engine/CommandLineParser.cpp
+++ b/remc2/engine/CommandLineParser.cpp
@@ -43,6 +43,7 @@ void CommandLineParser::Init(int argc, char **argv) {
     m_set_objective = false;
     m_set_level = false;
     m_test_network_chng1 = false;
+    m_memimage_path = "../remc2/memimages/";
 
     this->m_params.clear();
     for (int i=1; i < argc; ++i) {
@@ -52,7 +53,7 @@ void CommandLineParser::Init(int argc, char **argv) {
 }
 
 void CommandLineParser::InterpretParams() {
-    const auto &p = this->m_params;
+    const auto &params = this->m_params;
 
     // FIXME: check if multiple modes are selected and warn/fix
 
@@ -68,12 +69,13 @@ void CommandLineParser::InterpretParams() {
     auto is_in_all_params = [&all_modes](const std::string &s) {
         return end(all_modes) != std::find(begin(all_modes), end(all_modes), s);
     };
-    if (!std::any_of(begin(p), end(p), is_in_all_params)) {
+    if (!std::any_of(begin(params), end(params), is_in_all_params)) {
         this->m_params.emplace_back("--mode_release_game");
     }
 
     // check for modes (that define a set of params) and single params
-    for (const auto &param: p) {
+    for (auto p = params.cbegin(); p != params.cend(); ++p) {
+        const auto param = *p;
         if (param == "--mode_release_game") { //this is standard setting
             m_mode_release_game = true;
             m_no_show_new_procedures = true;
@@ -172,9 +174,8 @@ void CommandLineParser::InterpretParams() {
         else if (param == "--set_objective")                    m_set_objective = true;
         else if (param == "--set_level")                        m_set_level = true;
         else if (param == "--test_network_chng1")               m_test_network_chng1 = true;
-    
-    
-    
-    
+        else if (param == "--memimage_path") {
+            m_memimage_path = *(++p);
+        }
     }
 }

--- a/remc2/engine/CommandLineParser.cpp
+++ b/remc2/engine/CommandLineParser.cpp
@@ -43,7 +43,7 @@ void CommandLineParser::Init(int argc, char **argv) {
     m_set_objective = false;
     m_set_level = false;
     m_test_network_chng1 = false;
-    m_memimage_path = "../remc2/memimages/";
+    m_memimages_path = "../remc2/memimages/";
 
     this->m_params.clear();
     for (int i=1; i < argc; ++i) {
@@ -174,8 +174,8 @@ void CommandLineParser::InterpretParams() {
         else if (param == "--set_objective")                    m_set_objective = true;
         else if (param == "--set_level")                        m_set_level = true;
         else if (param == "--test_network_chng1")               m_test_network_chng1 = true;
-        else if (param == "--memimage_path") {
-            m_memimage_path = *(++p);
+        else if (param == "--memimages_path") {
+            m_memimages_path = *(++p);
         }
     }
 }

--- a/remc2/engine/CommandLineParser.h
+++ b/remc2/engine/CommandLineParser.h
@@ -49,7 +49,7 @@ class CommandLineParser {
         bool DoTestNetworkChng1() const {return m_test_network_chng1;};
 
         // settings
-        std::string GetMemimagePath() const {return m_memimage_path;};
+        std::string GetMemimagesPath() const {return m_memimages_path;};
 
     private:
         void InterpretParams();
@@ -92,7 +92,7 @@ class CommandLineParser {
         bool m_set_objective;
         bool m_set_level;
         bool m_test_network_chng1;
-        std::string m_memimage_path;
+        std::string m_memimages_path;
 };
 
 extern CommandLineParser CommandLineParams;

--- a/remc2/engine/CommandLineParser.h
+++ b/remc2/engine/CommandLineParser.h
@@ -48,47 +48,51 @@ class CommandLineParser {
         bool DoSetLevel() const {return m_set_level;};
         bool DoTestNetworkChng1() const {return m_test_network_chng1;};
 
+        // settings
+        std::string GetMemimagePath() const {return m_memimage_path;};
+
     private:
         void InterpretParams();
 
         std::vector<std::string> m_params;
 
         // modes: these control behaviour and set multiple other parameters
-        bool m_mode_release_game {false};
-        bool m_mode_playing_game {false};
-        bool m_mode_test_regressions_game {false};
-        bool m_mode_debug_afterload {false};
-        bool m_mode_debug_onstart {false};
-        bool m_mode_test_network {false};
+        bool m_mode_release_game;
+        bool m_mode_playing_game;
+        bool m_mode_test_regressions_game;
+        bool m_mode_debug_afterload;
+        bool m_mode_debug_onstart;
+        bool m_mode_test_network;
 
         // parameters
-        bool m_alternative_gamespeed_control {true};
-        bool m_analyze_entity {true};
-        bool m_auto_change_res {false};
-        bool m_copy_skip_config {false};
-        bool m_debug_sequences {false};
-        bool m_debug_sequences2 {false};
-        bool m_detect_dword_a {false};
-        bool m_disable_graphics_enhance {false};
-        bool m_fix_flyasistant {false};
-        bool m_fix_mouse {false};
-        bool m_interval_save {false};
-        bool m_load_edited_level {false};
-        bool m_mouse_off {false};
-        bool m_mouse_off2 {false};
-        bool m_move_player {false};
-        bool m_no_show_new_procedures {false};
-        bool m_off_pause_5 {false};
-        bool m_right_button {false};
-        bool m_test_regression {false};
-        bool m_test_renderers {false};
-        bool m_debugafterload {false};
-        bool m_graphics_debug {false};
-        bool m_hide_graphics {false};
-        bool m_rotate_player {false};
-        bool m_set_objective {false};
-        bool m_set_level {false};
-        bool m_test_network_chng1 {false};
+        bool m_alternative_gamespeed_control;
+        bool m_analyze_entity;
+        bool m_auto_change_res;
+        bool m_copy_skip_config;
+        bool m_debug_sequences;
+        bool m_debug_sequences2;
+        bool m_detect_dword_a;
+        bool m_disable_graphics_enhance;
+        bool m_fix_flyasistant;
+        bool m_fix_mouse;
+        bool m_interval_save;
+        bool m_load_edited_level;
+        bool m_mouse_off;
+        bool m_mouse_off2;
+        bool m_move_player;
+        bool m_no_show_new_procedures;
+        bool m_off_pause_5;
+        bool m_right_button;
+        bool m_test_regression;
+        bool m_test_renderers;
+        bool m_debugafterload;
+        bool m_graphics_debug;
+        bool m_hide_graphics;
+        bool m_rotate_player;
+        bool m_set_objective;
+        bool m_set_level;
+        bool m_test_network_chng1;
+        std::string m_memimage_path;
 };
 
 extern CommandLineParser CommandLineParams;

--- a/remc2/engine/CommandLineParserUT.cpp
+++ b/remc2/engine/CommandLineParserUT.cpp
@@ -19,7 +19,7 @@ TEST (DebugParameters, CommandLineParser) {
     };
     char *memimage_check[] = {
         (char*)"exe filename",
-        (char*)"--memimage_path",
+        (char*)"--memimages_path",
         (char*)"/home/user/remc2/memimages",
         nullptr
     };
@@ -38,5 +38,5 @@ TEST (DebugParameters, CommandLineParser) {
 
     CommandLineParams.Init(args, memimage_check);
 
-    EXPECT_EQ ("/home/user/remc2/memimages", CommandLineParams.GetMemimagePath());
+    EXPECT_EQ ("/home/user/remc2/memimages", CommandLineParams.GetMemimagesPath());
 }

--- a/remc2/engine/CommandLineParserUT.cpp
+++ b/remc2/engine/CommandLineParserUT.cpp
@@ -17,6 +17,12 @@ TEST (DebugParameters, CommandLineParser) {
         (char*)"dummy2",
         nullptr
     };
+    char *memimage_check[] = {
+        (char*)"exe filename",
+        (char*)"--memimage_path",
+        (char*)"/home/user/remc2/memimages",
+        nullptr
+    };
 
     CommandLineParams.Init(args, with_test_reg_game_group);
 
@@ -29,4 +35,8 @@ TEST (DebugParameters, CommandLineParser) {
 
     EXPECT_EQ (true, CommandLineParams.ModeReleaseGame());          // default mode if no other mode is selected
     EXPECT_EQ (false, CommandLineParams.ModeTestRegressionsGame()); // this mode should not be set
+
+    CommandLineParams.Init(args, memimage_check);
+
+    EXPECT_EQ ("/home/user/remc2/memimages", CommandLineParams.GetMemimagePath());
 }

--- a/remc2/engine/engine_support.cpp
+++ b/remc2/engine/engine_support.cpp
@@ -650,14 +650,14 @@ int test_0x6E8E_id_pointer(uint32_t adress) {
 int test_D41A0_id_pointer(uint32_t adress) {
 	if ((adress >= 0x2fc4) && (adress < 0x2fc5))return 2;//event
 
-	if ((adress >= 0x314d) && (adress < 0x3151))return 2;//clock
+	if ((adress >= 0x314d) && (adress < 0x3151))return 2;//clock - 4 bytes
 	if ((adress >= 0x3999) && (adress < 0x399d))return 2;//clock2 - 4 bytes
-	if ((adress >= 0x41e5) && (adress < 0x41e8))return 2;//clock3
-	if ((adress >= 0x4a31) && (adress < 0x4a34))return 2;//clock4
-	if ((adress >= 0x527d) && (adress < 0x5280))return 2;//clock5
-	if ((adress >= 0x5ac9) && (adress < 0x5acc))return 2;//clock6
-	if ((adress >= 0x6315) && (adress < 0x6318))return 2;//clock7
-	if ((adress >= 0x6b61) && (adress < 0x6b64))return 2;//clock8
+	if ((adress >= 0x41e5) && (adress < 0x41e9))return 2;//clock3 - 4 bytes
+	if ((adress >= 0x4a31) && (adress < 0x4a35))return 2;//clock4 - 4 bytes
+	if ((adress >= 0x527d) && (adress < 0x5281))return 2;//clock5 - 4 bytes
+	if ((adress >= 0x5ac9) && (adress < 0x5acd))return 2;//clock6 - 4 bytes
+	if ((adress >= 0x6315) && (adress < 0x6319))return 2;//clock7 - 4 bytes
+	if ((adress >= 0x6b61) && (adress < 0x6b65))return 2;//clock8 - 4 bytes
 
 	if ((adress >= 0x235) && (adress < 0x236))return 2;//music
 

--- a/remc2/engine/engine_support.cpp
+++ b/remc2/engine/engine_support.cpp
@@ -1,4 +1,6 @@
 #include "engine_support.h"
+#include "CommandLineParser.h"
+#include <string>
 
 #ifdef USE_DOSBOX
 extern DOS_Device* DOS_CON;
@@ -857,15 +859,15 @@ uint32_t compare_with_sequence_E7EE0(char* filename, uint8_t* adress, uint32_t  
 };
 
 uint32_t compare_with_sequence_D41A0(char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset, bool regressions) {
-	char findnamec[512];
+	std::string findname;
 	char findnamec2[512];
 	uint8_t* buffer = (uint8_t*)malloc(size);
 	FILE* fptestepc;
-	if (regressions)
-		sprintf(findnamec, "../remc2/memimages/regressions/sequence-%s.bin", filename);
+	if(regressions)
+		findname = CommandLineParams.GetMemimagesPath() + "/regressions/sequence-" + filename + ".bin";
 	else
-		sprintf(findnamec, "../../dosbox-x-remc2/vs2015/sequence-%s.bin", filename);
-	GetSubDirectoryPath(findnamec2, findnamec);
+		findname = std::string("../../dosbox-x-remc2/vs2015/sequence-") + filename + ".bin";
+	GetSubDirectoryPath(findnamec2, findname.c_str());
 	fptestepc = fopen(findnamec2, "rb");
 	if (fptestepc == NULL)
 	{
@@ -1136,15 +1138,15 @@ uint32_t compare_with_sequence_x_DWORD_F2C20ar(char* filename, uint8_t* adress, 
 };
 
 uint32_t compare_with_sequence_array_E2A74(char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset, bool regressions) {
-	char findnamec[512];
+	std::string findname;
 	char findnamec2[512];
 	uint8_t* buffer = (uint8_t*)malloc(size2);
 	FILE* fptestepc;
-	if (regressions)
-		sprintf(findnamec, "../remc2/memimages/regressions/sequence-%s.bin", filename);
+	if(regressions)
+		findname = CommandLineParams.GetMemimagesPath() + "/regressions/sequence-" + filename + ".bin";
 	else
-		sprintf(findnamec, "../../dosbox-x-remc2/vs2015/sequence-%s.bin", filename);
-	GetSubDirectoryPath(findnamec2, findnamec);
+		findname = std::string("../../dosbox-x-remc2/vs2015/sequence-") + filename + ".bin";
+	GetSubDirectoryPath(findnamec2, findname.c_str());
 	fptestepc = fopen(findnamec2, "rb");
 	if (fptestepc == NULL)
 	{
@@ -1249,15 +1251,15 @@ uint32_t compare_with_sequence_array_222BD3(char* filename, uint8_t* adress, uin
 };
 
 uint32_t compare_with_sequence(char* filename, uint8_t* adress, uint32_t  /*adressdos*/, long count, long size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset, bool regressions) {
-	char findnamec[512];
+	std::string findname;
 	char findnamec2[512];
 	uint8_t* buffer = (uint8_t*)malloc(size2);
 	FILE* fptestepc;
 	if(regressions)
-		sprintf(findnamec, "../remc2/memimages/regressions/sequence-%s.bin", filename);
+		findname = CommandLineParams.GetMemimagesPath() + "/regressions/sequence-" + filename + ".bin";
 	else
-		sprintf(findnamec, "../../dosbox-x-remc2/vs2015/sequence-%s.bin", filename);
-	GetSubDirectoryPath(findnamec2, findnamec);
+		findname = std::string("../../dosbox-x-remc2/vs2015/sequence-") + filename + ".bin";
+	GetSubDirectoryPath(findnamec2, findname.c_str());
 	fptestepc = fopen(findnamec2, "rb");
 	if (fptestepc == NULL)
 	{

--- a/remc2/engine/engine_support.cpp
+++ b/remc2/engine/engine_support.cpp
@@ -571,7 +571,7 @@ void support_end() {
 	if (x_DWORD_D4188t_spritestr) delete[](x_DWORD_D4188t_spritestr);
 }
 
-void loadfromsnapshot(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size) {
+void loadfromsnapshot(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size) {
 	char findnamec[500];
 	FILE* fptestepc;
 	sprintf(findnamec, "../remc2/memimages/engine-memory-%s", filename);
@@ -581,7 +581,7 @@ void loadfromsnapshot(char* filename, uint8_t* adress, uint32_t adressdos, uint3
 	fclose(fptestepc);
 };
 
-void loadfromsnapshot2(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size) {
+void loadfromsnapshot2(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size) {
 	char findnamec[500];
 	FILE* fptestepc;
 	uint32_t subadress;
@@ -595,7 +595,7 @@ void loadfromsnapshot2(char* filename, uint8_t* adress, uint32_t adressdos, uint
 	fclose(fptestepc);
 };
 
-uint32_t compare_with_snapshot(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size, uint8_t* origbyte, uint8_t* copybyte) {
+uint32_t compare_with_snapshot(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size, uint8_t* origbyte, uint8_t* copybyte) {
 	char findnamec[500];
 	uint8_t* buffer = (uint8_t*)malloc(size);
 	FILE* fptestepc;
@@ -753,7 +753,7 @@ int test_222BD3_id_pointer(uint32_t adress) {
 	return 0;
 }
 
-uint32_t compare_with_snapshot_D41A0(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size, uint8_t* origbyte, uint8_t* copybyte) {
+uint32_t compare_with_snapshot_D41A0(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size, uint8_t* origbyte, uint8_t* copybyte) {
 	char findnamec[500];
 	uint8_t* buffer = (uint8_t*)malloc(size);
 	FILE* fptestepc;
@@ -805,7 +805,7 @@ uint32_t compare_with_snapshot_D41A0(char* filename, uint8_t* adress, uint32_t a
 	return(i);
 };
 
-uint32_t compare_with_sequence_E7EE0(char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset) {
+uint32_t compare_with_sequence_E7EE0(const char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset) {
 	char findnamec[500];
 	uint8_t* buffer = (uint8_t*)malloc(size2);
 	FILE* fptestepc;
@@ -858,7 +858,7 @@ uint32_t compare_with_sequence_E7EE0(char* filename, uint8_t* adress, uint32_t  
 	return(i);
 };
 
-uint32_t compare_with_sequence_D41A0(char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset, bool regressions) {
+uint32_t compare_with_sequence_D41A0(const char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset, bool regressions) {
 	std::string findname;
 	char findnamec2[512];
 	uint8_t* buffer = (uint8_t*)malloc(size);
@@ -915,7 +915,7 @@ uint32_t compare_with_sequence_D41A0(char* filename, uint8_t* adress, uint32_t  
 	return(i);
 };
 
-uint32_t compare_0x6E8E(char* filename, uint8_t* adress, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset) {
+uint32_t compare_0x6E8E(const char* filename, uint8_t* adress, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset) {
 	char findnamec[500];
 	uint8_t* buffer = (uint8_t*)malloc(size);
 	FILE* fptestepc;
@@ -967,7 +967,7 @@ uint32_t compare_0x6E8E(char* filename, uint8_t* adress, uint32_t count, uint32_
 	return(i);
 };
 
-uint32_t compare_with_sequence_EA3E4(char* filename, type_event_0x6E8E** adress, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte) {
+uint32_t compare_with_sequence_EA3E4(const char* filename, type_event_0x6E8E** adress, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte) {
 	char findnamec[500];
 	uint8_t* buffer = (uint8_t*)malloc(size * 0x3E9);
 	FILE* fptestepc;
@@ -1025,7 +1025,7 @@ uint32_t compare_with_sequence_EA3E4(char* filename, type_event_0x6E8E** adress,
 	return(1);
 };
 
-uint32_t compare_with_sequence_D41A0_4(char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset) {
+uint32_t compare_with_sequence_D41A0_4(const char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset) {
 	char findnamec[500];
 	uint8_t* buffer = (uint8_t*)malloc(size);
 	FILE* fptestepc;
@@ -1082,7 +1082,7 @@ int test_F2C20ar_id_pointer(uint32_t adress) {
 	return 0;
 }
 
-uint32_t compare_with_sequence_x_DWORD_F2C20ar(char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, int* posdiff) {
+uint32_t compare_with_sequence_x_DWORD_F2C20ar(const char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, int* posdiff) {
 	char findnamec[500];
 	uint8_t* buffer = (uint8_t*)malloc(size);
 	FILE* fptestepc;
@@ -1137,7 +1137,7 @@ uint32_t compare_with_sequence_x_DWORD_F2C20ar(char* filename, uint8_t* adress, 
 	return(diffindex);
 };
 
-uint32_t compare_with_sequence_array_E2A74(char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset, bool regressions) {
+uint32_t compare_with_sequence_array_E2A74(const char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset, bool regressions) {
 	std::string findname;
 	char findnamec2[512];
 	uint8_t* buffer = (uint8_t*)malloc(size2);
@@ -1195,7 +1195,7 @@ uint32_t compare_with_sequence_array_E2A74(char* filename, uint8_t* adress, uint
 	return(i);
 };
 
-uint32_t compare_with_sequence_array_222BD3(char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, int* posdiff) {
+uint32_t compare_with_sequence_array_222BD3(const char* filename, uint8_t* adress, uint32_t  /*adressdos*/, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, int* posdiff) {
 	char findnamec[500];
 	uint8_t* buffer = (uint8_t*)malloc(size);
 	FILE* fptestepc;
@@ -1250,7 +1250,7 @@ uint32_t compare_with_sequence_array_222BD3(char* filename, uint8_t* adress, uin
 	return(i);
 };
 
-uint32_t compare_with_sequence(char* filename, uint8_t* adress, uint32_t  /*adressdos*/, long count, long size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset, bool regressions) {
+uint32_t compare_with_sequence(const char* filename, const uint8_t* adress, uint32_t  /*adressdos*/, long count, long size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset, bool regressions) {
 	std::string findname;
 	char findnamec2[512];
 	uint8_t* buffer = (uint8_t*)malloc(size2);
@@ -1307,7 +1307,7 @@ uint32_t compare_with_sequence(char* filename, uint8_t* adress, uint32_t  /*adre
 	return(i);
 };
 
-void mine_texts(char* filename, uint32_t adressdos, uint32_t count, char* outfilename) {
+void mine_texts(const char* filename, uint32_t adressdos, uint32_t count, char* outfilename) {
 	char findnamec[500];
 	FILE* fptestepc;
 	FILE* fileout;
@@ -1440,7 +1440,7 @@ inline void setRGBA(png_byte* ptr, uint8_t* val)
 	ptr[3] = val[3];
 }
 
-int writeImage(char* filename, int width, int height, uint8_t* buffer, char* title)
+int writeImage(const char* filename, int width, int height, uint8_t* buffer, char* title)
 {
 	int code = 0;
 	FILE* fp = NULL;
@@ -1576,7 +1576,7 @@ unsigned char* createBitmapInfoHeader(int height, int width) {
 	return infoHeader;
 }
 
-void writeImageBMP(char* imageFileName, int width, int height, uint8_t* image)
+void writeImageBMP(const char* imageFileName, int width, int height, uint8_t* image)
 {
 	int pitch = bytesPerPixel * width;
 	unsigned char padding[3] = { 0, 0, 0 };
@@ -1601,7 +1601,7 @@ void writeImageBMP(char* imageFileName, int width, int height, uint8_t* image)
 	//free(infoHeader);
 }
 
-void write_posistruct_to_png(uint8_t* buffer, int width, int height, char* filename) {
+void write_posistruct_to_png(uint8_t* buffer, int width, int height, const char* filename) {
 	//int width = actposistruct->width;
 	//int height = actposistruct->height;
 	//png_bytep *row_pointers=(png_bytep*)malloc(sizeof(row_pointers)*height);
@@ -1733,7 +1733,7 @@ void write_posistruct_to_png(uint8_t* buffer, int width, int height, char* filen
 	if (row != NULL) free(row);*/
 }
 
-void buff_posistruct_to_png(uint8_t* buffer, int width, int height, char* filename) {
+void buff_posistruct_to_png(uint8_t* buffer, int width, int height, const char* filename) {
 	//png_bytep row = NULL;
 	uint8_t Palettebuffer[768];
 	FILE* palfile;

--- a/remc2/engine/engine_support.h
+++ b/remc2/engine/engine_support.h
@@ -1002,26 +1002,26 @@ extern type_array_str_E2A74 str_E2A74;
 void support_begin();
 void support_end();
 
-void loadfromsnapshot(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size);
-void loadfromsnapshot2(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size);
-uint32_t compare_with_snapshot(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size, uint8_t* origbyte, uint8_t* copybyte);
-uint32_t compare_with_sequence(char* filename, uint8_t* adress, uint32_t adressdos, long count, long size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset = 0, bool regressions=false);
-uint32_t compare_with_sequence_E7EE0(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset = 0);
-uint32_t compare_with_snapshot_D41A0(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size, uint8_t* origbyte, uint8_t* copybyte);
-uint32_t compare_with_sequence_D41A0(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset = 0, bool regressions = false);
-uint32_t compare_with_sequence_array_E2A74(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset = 0, bool regressions = false);
-uint32_t compare_with_sequence_x_DWORD_F2C20ar(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, int* posdiff);
-uint32_t compare_with_sequence_array_222BD3(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, int* posdiff);
-uint32_t compare_with_sequence_D41A0_4(char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset = 0);
-uint32_t compare_with_sequence_EA3E4(char* filename, type_event_0x6E8E** adress, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte);
-uint32_t compare_0x6E8E(char* filename, uint8_t* adress, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset = 0);
+void loadfromsnapshot(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size);
+void loadfromsnapshot2(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size);
+uint32_t compare_with_snapshot(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size, uint8_t* origbyte, uint8_t* copybyte);
+uint32_t compare_with_sequence(const char* filename, const uint8_t* adress, uint32_t adressdos, long count, long size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset = 0, bool regressions=false);
+uint32_t compare_with_sequence_E7EE0(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset = 0);
+uint32_t compare_with_snapshot_D41A0(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t size, uint8_t* origbyte, uint8_t* copybyte);
+uint32_t compare_with_sequence_D41A0(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset = 0, bool regressions = false);
+uint32_t compare_with_sequence_array_E2A74(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size1, uint32_t size2, uint8_t* origbyte, uint8_t* copybyte, long offset = 0, bool regressions = false);
+uint32_t compare_with_sequence_x_DWORD_F2C20ar(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, int* posdiff);
+uint32_t compare_with_sequence_array_222BD3(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, int* posdiff);
+uint32_t compare_with_sequence_D41A0_4(const char* filename, uint8_t* adress, uint32_t adressdos, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset = 0);
+uint32_t compare_with_sequence_EA3E4(const char* filename, type_event_0x6E8E** adress, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte);
+uint32_t compare_0x6E8E(const char* filename, uint8_t* adress, uint32_t count, uint32_t size, uint8_t* origbyte, uint8_t* copybyte, long offset = 0);
 void add_compare(uint32_t adress, bool debugafterload, int stopstep = -1, bool skip = false,int exitindex=1000000,int skip2=0);
 void add_compare2(uint32_t adress, uint8_t* memadress, uint32_t dosmemadress, uint32_t size, bool debugafterload, int stopstep = -1, bool skip = false, int exitindex = 1000000);
 void writehex(uint8_t* buffer, uint32_t count);
 
-void mine_texts(char* filename, uint32_t adressdos, uint32_t count, char* outfilename);
-int writeImage(char* filename, int width, int height, uint8_t* buffer, char* title);
-void writeImageBMP(char* imageFileName, int width, int height, uint8_t* image);
+void mine_texts(const char* filename, uint32_t adressdos, uint32_t count, char* outfilename);
+int writeImage(const char* filename, int width, int height, uint8_t* buffer, char* title);
+void writeImageBMP(const char* imageFileName, int width, int height, uint8_t* image);
 
 /*
 typedef struct {//lenght 8
@@ -2051,7 +2051,7 @@ extern type_D41A0_BYTESTR_0 D41A0_0;
 
 /*void x_D41A0_BYTEARRAY_0_to_x_D41A0_BYTESTR_0();
 void x_D41A0_BYTESTR_0_to_x_D41A0_BYTEARRAY_0();*/
-void write_posistruct_to_png(uint8_t* buffer, int width, int height, char* filename);
+void write_posistruct_to_png(uint8_t* buffer, int width, int height, const char* filename);
 
 int my_sign32(int32_t var);
 int my_sign16(int16_t var);

--- a/tests/testRegressions.sh
+++ b/tests/testRegressions.sh
@@ -7,7 +7,8 @@ remc2_executable=./build/Debug/inst/bin/remc2
 data_location=~/.local/share/remc2/regression_tests
 
 # !NOTE!: the regression files have to be exactly at ../memimages/regressions relative to the remc2 executable
-regression_files=./build/Debug/inst/memimages/regressions/
+memimages_path=$(realpath ./build/Debug/inst/memimages/)
+regression_files=$memimages_path/regressions/
 
 test_level() {
     level=$1
@@ -16,12 +17,14 @@ test_level() {
     rm -f "${regression_files}/*"
     cp "${data_location}/level${level}/"* "${regression_files}"
     gamelevel="$(($level-1))"
-    ./build/Debug/inst/bin/remc2 --mode_test_regressions_game reglevel $gamelevel 2>&1 | grep 'Regression compare sequence error'
+    pushd ./build/Debug/inst/bin > /dev/null
+    ./remc2 reglevel $gamelevel --mode_test_regressions_game --memimages_path $memimages_path 2>&1 | grep 'Regression compare sequence error'
     if [ ${PIPESTATUS[0]} -eq 20 ]; then
         echo "test level$level ok"
     else
         echo "test level$level failed"
     fi
+    popd > /dev/null
 }
 
 for i in `seq 1 25`; do


### PR DESCRIPTION
- Added a command line parameter that reads a path to the memimages that are used by regression tests.
- Updated the UT
- Updated the launch.json of VSCode for running the game and running regression tests
- The memimages param can be used as a blueprint for how to read data from the CLI - not just flags