### PR TITLE
add support for generic joysticks

### DIFF
--- a/remc2/engine/Basic.cpp
+++ b/remc2/engine/Basic.cpp
@@ -93,6 +93,8 @@ uint8_t* x_DWORD_18070C; // weak
 uint8_t* x_DWORD_180714; // weak
 uint8_t* x_DWORD_180718; // weak
 
+extern axis_2d x_WORD_E3760_mouse;
+
 //basic graphics
 
 char x_BYTE_D41CE = 0; // weak
@@ -1769,6 +1771,11 @@ void VGA_DrawPlayerCoordData(int x, int y)
 			" Yaw: " + std::to_string(rotData.yaw);
 
 		VGA_Draw_stringXYtoBuffer(playerRotationStr.c_str(), x, y + 8, pdwScreenBuffer_351628, 'S');
+#if 0
+		axis_2d mouseData = x_WORD_E3760_mouse;
+		std::string mouseCoordStr = "x: " + std::to_string(mouseData.x) + " y: " + std::to_string(mouseData.y);
+		VGA_Draw_stringXYtoBuffer(mouseCoordStr.c_str(), x, y + 16, pdwScreenBuffer_351628, 'S');
+#endif
 	}
 }
 

--- a/remc2/portability/port_sdl_vga_mouse.cpp
+++ b/remc2/portability/port_sdl_vga_mouse.cpp
@@ -22,6 +22,7 @@ uint8_t m_fontBuffer[256 * 256];
 SDL_Surface* m_surfaceFont = nullptr;
 uint8_t m_smallFontBuffer[128 * 128];
 SDL_Surface* m_smallSurfaceFont = nullptr;
+SDL_Joystick* m_gameController = NULL;
 
 uint8_t LastPressedKey_1806E4; //3516e4
 int8_t pressedKeys_180664[128]; // idb
@@ -114,7 +115,7 @@ void VGA_Init(Uint32  /*flags*/, int width, int height, bool maintainAspectRatio
 	if (!inited)
 	{
 		//Initialize SDL
-		if (SDL_Init(SDL_INIT_VIDEO) < 0)
+		if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0)
 		{
 			Logger->error("SDL could not initialize! SDL_Error: {}", SDL_GetError());
 			exit(0);
@@ -122,6 +123,15 @@ void VGA_Init(Uint32  /*flags*/, int width, int height, bool maintainAspectRatio
 		}
 		else
 		{
+			m_gameController = SDL_JoystickOpen(0);
+			if( m_gameController == NULL ) {
+				Logger->debug("joystick not detected. SDL Error: {}", SDL_GetError() );
+			} else {
+                if (SDL_JoystickEventState(SDL_ENABLE) != 1) {
+				    Logger->error("unable to initialize joystick events. SDL Error: {}", SDL_GetError() );
+			    }
+            }
+
 			init_sound();
 
 			SDL_ShowCursor(0);
@@ -813,6 +823,117 @@ bool handleSpecialKeys(const SDL_Event &event) {
 	return specialKey;
 }
 
+
+#define          JOY_MIN_X  0
+#define          JOY_MIN_Y  0
+#define JOYSTICK_DEAD_ZONE  128 // might be needed for joysticks that generate noise while in the rest position
+
+#define      JOY_UPDATED_X  0x1
+#define      JOY_UPDATED_Y  0x2
+#define   JOY_BTN_RELEASED  0x4
+#define    JOY_BTN_PRESSED  0x8
+
+int32_t joy_x, joy_y;
+int32_t joy_rest_x, joy_rest_y;
+int32_t joy_max_x, joy_max_y;
+
+/// \brief set the x,y coord of the joystick rest position
+/// \param x coordinate where the mouse pointer needs to end up when the joystick is in it's rest position
+/// \param y coordinate where the mouse pointer needs to end up when the joystick is in it's rest position
+void joystick_set_rest(const int32_t x, const int32_t y)
+{
+	Logger->trace("pointer rest at {},{} window size {},{}", x, y, joy_max_x, joy_max_y);
+	joy_rest_x = x;
+	joy_rest_y = y;
+	joy_x = x;
+	joy_y = y;
+}
+
+/// \brief set the maximal coordinate values that the joystick has to reach
+/// \param gameResWidth maximum x value
+/// \param gameResHeight maximum y value
+void joystick_init_limits(const int gameResWidth, const int gameResHeight)
+{
+	joy_max_x = gameResWidth;
+	joy_max_y = gameResHeight;
+	joystick_set_rest(joy_max_x >> 1, joy_max_y >> 1);
+}
+
+/// \brief emulate a mouse based on data provided by a USB joystick
+/// \param button_id  button that was pressed or released
+/// \param axis_values SDL provides values in the -32768 ..  32767 range
+/// \param flags  can be one of JOY_UPDATED_X JOY_UPDATED_Y JOY_BTN_RELEASED JOY_BTN_PRESSED
+void joystick_event_mgr(const uint16_t button_id, const int16_t axis_value, const uint8_t flags)
+{
+	uint16_t joy_button_state = 0;
+
+	if (flags == JOY_UPDATED_X) {
+		if ((axis_value < JOYSTICK_DEAD_ZONE) && (axis_value > -JOYSTICK_DEAD_ZONE)) {
+			joy_x = joy_rest_x;
+		} else {
+            // use two different linear interpolation equations since the
+            // resting coordinate is not always the center of the display
+            if (axis_value > 0) {
+			    joy_x = (((joy_max_x - joy_rest_x) * axis_value) >> 15) + joy_rest_x;
+            } else {
+			    joy_x = ((joy_rest_x * axis_value) >> 15) + joy_rest_x;
+            }
+
+			if (joy_x < JOY_MIN_X) {
+				joy_x = JOY_MIN_X;
+			} else if (joy_x > joy_max_x) {
+				joy_x = joy_max_x;
+			}
+	        //Logger->trace("X raw {}, output {}, rest {}, max {}", axis_value, joy_x, joy_rest_x, joy_max_x);
+		}
+	} else if (flags == JOY_UPDATED_Y) {
+		if ((axis_value < JOYSTICK_DEAD_ZONE) && (axis_value > -JOYSTICK_DEAD_ZONE)) {
+			joy_y = joy_rest_y;
+		} else {
+            // use two different linear interpolation equations since the
+            // resting coordinate is not always the center of the display
+            if (axis_value > 0) {
+			    joy_y = (((joy_max_y - joy_rest_y) * axis_value) >> 15) + joy_rest_y;
+            } else {
+			    joy_y = ((joy_rest_y * axis_value) >> 15) + joy_rest_y;
+            }
+
+			if (joy_y < JOY_MIN_Y) {
+				joy_y = JOY_MIN_Y;
+			} else if (joy_y > joy_max_y) {
+				joy_y = joy_max_y;
+			}
+	        //Logger->trace("Y raw {}, output {}, rest {}, max {}", axis_value, joy_y, joy_rest_y, joy_max_y);
+		}
+	} else if (flags == JOY_BTN_PRESSED) {
+		switch (button_id) {
+			case 0:
+				joy_button_state |= 0x2;
+				break;
+			case 1:
+				joy_button_state |= 0x8;
+				break;
+			case 2:
+				joy_button_state |= 0x20;
+				break;
+		}
+	} else if (flags == JOY_BTN_RELEASED) {
+		switch (button_id) {
+			case 0:
+				joy_button_state |= 0x4;
+				break;
+			case 1:
+				joy_button_state |= 0x10;
+				break;
+			case 2:
+				joy_button_state |= 0x40;
+				break;
+		}
+	}
+
+	MouseEvents(joy_button_state, joy_x, joy_y);
+}
+
 int mousex, mousey;
 bool pressed = false;
 uint16_t lastchar = 0;
@@ -826,6 +947,26 @@ int events()
 	{
 		switch (event.type)
 		{
+		case SDL_JOYAXISMOTION:
+			if (event.jaxis.which == 0) {
+				// motion on controller 0
+				if (event.jaxis.axis == 0) {
+					joystick_event_mgr(0, event.jaxis.value, JOY_UPDATED_X);
+				} else if (event.jaxis.axis == 1) {
+					joystick_event_mgr(0, event.jaxis.value, JOY_UPDATED_Y);
+				}
+			}
+			break;
+		case SDL_JOYBUTTONDOWN:
+			if (event.jbutton.which == 0) {
+				joystick_event_mgr(event.jbutton.button, 0, JOY_BTN_PRESSED);
+			}
+			break;
+		case SDL_JOYBUTTONUP:
+			if (event.jbutton.which == 0) {
+				joystick_event_mgr(event.jbutton.button, 0, JOY_BTN_RELEASED);
+			}
+			break;
 		case SDL_KEYDOWN:
 			pressed = true;
 			lastchar = (event.key.keysym.scancode << 8) + event.key.keysym.sym;
@@ -915,6 +1056,7 @@ int events()
 
 void VGA_Set_mouse(int16_t x, int16_t y) {
 	SDL_WarpMouseInWindow(m_window, x, y);
+	joystick_set_rest(x, y);
 };
 
 void VGA_Blit(Uint8* srcBuffer) {
@@ -1065,6 +1207,8 @@ void VGA_Debug_Blit(int width, int height, Uint8* buffer) {
 
 void VGA_close()
 {
+	SDL_JoystickClose(m_gameController);
+	m_gameController = NULL;
 	clean_up_sound();
 	SDL_FreeSurface(m_surfaceFont);
 	m_surfaceFont = nullptr;

--- a/remc2/portability/port_sdl_vga_mouse.h
+++ b/remc2/portability/port_sdl_vga_mouse.h
@@ -55,6 +55,8 @@ uint16_t VGA_read_char_from_buffer();
 void VGA_Set_mouse(int16_t a1, int16_t a2);
 void setPress(bool locpressed, uint16_t loclastchar);
 
+void joystick_init_limits(const int gameResWidth, const int gameResHeight);
+
 void VGA_mouse_clear_keys();
 void VGA_cleanKeyBuffer();
 void Draw_debug_matrix1();

--- a/remc2/sub_main.cpp
+++ b/remc2/sub_main.cpp
@@ -51866,10 +51866,13 @@ void sub_54800_read_and_decompress_tables(MapType_t a1)//235800
 }
 
 //----- (000548B0) --------------------------------------------------------
+// returns viewport from menu to flight mode
 void sub_548B0(type_str_0x2BDE* a1x)//2358b0
 {
 	if (a1x->word_0x007_2BE4_11237 == D41A0_0.LevelIndex_0xc)
-		SetMousePositionInMemory_5BDC0(a1x->dword_0x3E6_2BE4_12228.position_backup_20.x, a1x->dword_0x3E6_2BE4_12228.position_backup_20.y);
+		//SetMousePositionInMemory_5BDC0(a1x->dword_0x3E6_2BE4_12228.position_backup_20.x, a1x->dword_0x3E6_2BE4_12228.position_backup_20.y);
+		// if a joystick is used, do not set that random resting point from above
+		SetMousePositionInMemory_5BDC0(320, 240);
 }
 
 //----- (000548F0) --------------------------------------------------------
@@ -53066,6 +53069,7 @@ int sub_main(int argc, char** argv, char**  /*envp*/)//236F70
 
 		Logger->debug("Initializing graphics Width: {} Height: {}", windowResWidth, windowResHeight);
 		VGA_Init(windowResWidth, windowResHeight, maintainAspectRatio, displayIndex);
+		joystick_init_limits(gameResWidth, gameResHeight);
 
 		//char maindir[1024];
 		Logger->info("Finding Game Data...");
@@ -78392,11 +78396,13 @@ int16_t sub_89B60_aplicate_setting(uint8_t a1)//26ab60
 	switch (a1)
 	{
 	case 1u:
+		// i_Glasses (Virtual I-O) joystick
 		v1 = sub_8B600(unk_18058Cstr);//fix it
 		if ((signed __int16)v1 != -1)
 			goto LABEL_3;
 		break;
 	case 2u:
+		// VFX1 CyberPuck joystick
 		if (sub_75650())//fix it
 		{
 			v1 = 1;


### PR DESCRIPTION
joystick implementation that works by changing the in-game mouse structures

what works:
 - flight mode 10/10. the joystick rest coords can be anywhere inside 0,0 gameResW,H and the coordinate remapping works properly - I'm able to reach the edges of the window if a menu is popped-up.
 - spell selection 7/10. in the original game (640x480) the spell bar occupied all the bottom part of the display. so that the individual spells are large enough to pick with the unwieldy joystick. the higher gameResW,H is selected the harder it will be to select a spell. I think the spell boxes should be scaled to resemble the original game.
 - big stone menu, level selection widows are not gameResW,H so only half the joystick's movement covers the entire window. which makes selection difficult. 3/10 use a mouse.

tell me what you think.

cheers,
peter