### PR TITLE
fix: remove change that was culling sprite on the left too much

### DIFF
--- a/remc2/engine/GameRenderHD.cpp
+++ b/remc2/engine/GameRenderHD.cpp
@@ -4303,7 +4303,7 @@ void GameRenderHD::DrawSprite_41BD3(uint32 a1)
 							for (i = v159; i; i--)
 							{
 								v133 = v165[1];
-								if ((v133 > 0) && (*v165 > 0))
+								if (v133 > 0)
 								{
 									//adress 2237d3
 


### PR DESCRIPTION
(cherry picked from commit d9b7ffaa759c165ed5775b847c2579043e33fea9)