### PR TITLE
Fix endless loop when defeating end boss

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Game",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/Debug/inst/bin/remc2",
+            "program": "${workspaceFolder}/build_vscode/inst/bin/remc2",
             "args": [
             ],
             "stopAtEntry": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,9 @@
     "files.associations": {
         "iostream": "cpp",
         "cstdlib": "cpp",
-        "filesystem": "cpp"
+        "filesystem": "cpp",
+        "cstring": "cpp",
+        "type_traits": "cpp"
     },
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
 }

--- a/remc2/engine/GameUI.cpp
+++ b/remc2/engine/GameUI.cpp
@@ -3245,7 +3245,7 @@ void ComputeTextboxSizesFromTextWords_89420(Type_TextBox_1804B0* textbox, const 
 				lastLineIndex = 0;
 				while (lastLineIndex < textBufferLenght - 1)
 				{
-					for (textIndex = lastLineIndex + lineCharWidth; text[lastLineIndex + textIndex] != 32 && textIndex < textBufferLenght - 1; textIndex--);//to previous word
+					for (textIndex = lastLineIndex + lineCharWidth; text[textIndex] != 32 && textIndex < textBufferLenght - 1; textIndex--);//to previous word
 					lastLineIndex = textIndex + 1;
 					countOfLines++;
 				}


### PR DESCRIPTION
There was a bug in the line wrapping loop that computes the size of text boxes.
It ended up in en endless loop at the end of the final level when it cannot determine the number of needed lines to display the victory message.