### PR TITLE
Fix regression tests on Linux

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,9 @@
         "cstdlib": "cpp",
         "filesystem": "cpp",
         "cstring": "cpp",
-        "type_traits": "cpp"
+        "type_traits": "cpp",
+        "functional": "cpp",
+        "thread": "cpp"
     },
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
 }

--- a/remc2-regression-test/tests.cpp
+++ b/remc2-regression-test/tests.cpp
@@ -1,4 +1,4 @@
-﻿// Unit-tests.cpp : Tento soubor obsahuje funkci main. Provádění programu se tam zahajuje a ukončuje.
+// Unit-tests.cpp : This file contains the main function. This is where the program execution starts and ends.
 //
 #include <chrono>
 #include <thread>
@@ -10,8 +10,8 @@ int CountFailedRegressionTests() {
 	int numFailedTests = 0;
 
 	Logger->info("--- Regressions tests ---");
-	for (int i = 22; i <= 22; i++)
-		if (i != 22)
+	for (int i = 1; i <= 25; i++)
+		if (i != 22 && i != 25)
 			if (run_regtest(i) != 0)
 			{
 				numFailedTests++;
@@ -28,6 +28,9 @@ int CountFailedRegressionTests() {
 	//   168 byte per element
 	//   -> diff in the 23rd element struct_0x6E8E[22] at position 140
 	//       -> maxMana_0x8C_140 and word_0x94_148
+
+	// diff in level 25
+	// byte_counter_current_objective_box_0x36E04 = 0 instead of 200
 
 	return numFailedTests;
 }

--- a/remc2-regression-test/tests.cpp
+++ b/remc2-regression-test/tests.cpp
@@ -10,12 +10,24 @@ int CountFailedRegressionTests() {
 	int numFailedTests = 0;
 
 	Logger->info("--- Regressions tests ---");
-	for (int i = 1; i <= 25; i++)
+	for (int i = 22; i <= 22; i++)
 		if (i != 22)
 			if (run_regtest(i) != 0)
 			{
 				numFailedTests++;
 			}
+
+	// diff in level 22:
+	//   the first frame with a diff has it at 0x7dba and the following bytes:
+	//      buffer[32186] = 53   adress[32186] = 150
+	//      buffer[32187] = 120   adress[32187] = 189
+	//      buffer[32194] = 18   adress[32194] = 0
+	//      buffer[32195] = 4   adress[32195] = 0
+	//   in type_event_0x6E8E struct_0x6E8E[1000];
+	//   size of struct_0x6E8E[1000] is 0x29040 = 168000
+	//   168 byte per element
+	//   -> diff in the 23rd element struct_0x6E8E[22] at position 140
+	//       -> maxMana_0x8C_140 and word_0x94_148
 
 	return numFailedTests;
 }

--- a/remc2/engine/Basic.cpp
+++ b/remc2/engine/Basic.cpp
@@ -3569,7 +3569,7 @@ void Convert_from_shadow_D41A0_BYTESTR_0(type_shadow_D41A0_BYTESTR_0* from, type
 	to->stageIndex_0x36E01 = from->byte_0x36E01;
 	to->byte_0x36E02 = from->byte_0x36E02;
 	to->byte_0x36E03 = from->byte_0x36E03;
-	to->byte_0x36E04 = from->byte_0x36E04;
+	to->byte_counter_current_objective_box_0x36E04 = from->byte_counter_current_objective_box_0x36E04;
 	for (int i = 0; i < 6; i++)to->stub3k[i] = from->stub3k[i];
 	to->byte_0x36E0B = from->byte_0x36E0B;
 	for (int i = 0; i < 11; i++)to->stubend[i] = from->stubend[i];
@@ -3762,7 +3762,7 @@ void Convert_to_shadow_D41A0_BYTESTR_0(type_D41A0_BYTESTR_0* from, type_shadow_D
 	to->byte_0x36E01 = from->stageIndex_0x36E01;
 	to->byte_0x36E02 = from->byte_0x36E02;
 	to->byte_0x36E03 = from->byte_0x36E03;
-	to->byte_0x36E04 = from->byte_0x36E04;
+	to->byte_counter_current_objective_box_0x36E04 = from->byte_counter_current_objective_box_0x36E04;
 	for (int i = 0; i < 6; i++)to->stub3k[i] = from->stub3k[i];
 	to->byte_0x36E0B = from->byte_0x36E0B;
 	for (int i = 0; i < 11; i++)to->stubend[i] = from->stubend[i];

--- a/remc2/engine/GameUI.cpp
+++ b/remc2/engine/GameUI.cpp
@@ -598,7 +598,7 @@ void DrawCurrentObjectiveTextbox_30630(uint8_t scale)//211630
 			else if (x_D41A0_BYTEARRAY_4_struct.setting_38545 & 0x20
 				&& !D41A0_0.struct_0x3659C[D41A0_0.LevelIndex_0xc].substr_3659C.ObjectiveText_1)
 			{
-				D41A0_0.byte_0x36E04 = 0;
+				D41A0_0.byte_counter_current_objective_box_0x36E04 = 0;
 			}
 			else
 			{
@@ -669,6 +669,9 @@ void sub_41B60()//222b60
 //----- (00052E90) --------------------------------------------------------
 void SetMenuCursorPosition_52E90(type_str_0x2BDE* playStr, uint16_t type, bool useSound)//233e90
 {
+	// type == 0 -> hide in-game dialog
+	// type == 9 -> show in-game settings dialog
+	// type == 13 -> show in-game abandon game yes/no dialog
 	uint8_t temp_12221 = playStr->byte_0x3DF_2BE4_12221;
 	playStr->byte_0x3DF_2BE4_12221 = type;
 	if (playStr->word_0x007_2BE4_11237 != D41A0_0.LevelIndex_0xc)
@@ -712,7 +715,7 @@ void SetMenuCursorPosition_52E90(type_str_0x2BDE* playStr, uint16_t type, bool u
 	case 0xC:
 	case 0xD:
 	case 0xE:
-		D41A0_0.byte_0x36E04 = 0;
+		D41A0_0.byte_counter_current_objective_box_0x36E04 = 0;  // hide objective message box
 		break;
 	default:
 		break;

--- a/remc2/engine/PlayerInput.cpp
+++ b/remc2/engine/PlayerInput.cpp
@@ -1322,35 +1322,35 @@ void sub_1A970_change_game_settings(char a1, int a2, int a3)//1fb970
 		v17 = D41A0_0.terrain_2FECE.MapType;
 		if (v17 == MapType_t::Day)
 		{
-      if (a2)
-      {
-        //v3 = x_D41A0_BYTEARRAY_4_struct.dwordindex_0;
-        //v19 = x_D41A0_BYTEARRAY_4[11] - 1;
-        x_D41A0_BYTEARRAY_4_struct.brightness_11--;// = v19;
-        if (x_D41A0_BYTEARRAY_4_struct.brightness_11 >= 0)
-          goto LABEL_86;
-        if (!a3)
-        {
-          x_D41A0_BYTEARRAY_4_struct.brightness_11 = 4;
-          goto LABEL_86;
-        }
-      }
-      else
-      {
-        //v3 = x_D41A0_BYTEARRAY_4_struct.dwordindex_0;
-        //v18 = x_D41A0_BYTEARRAY_4[11] + 1;
-        x_D41A0_BYTEARRAY_4_struct.brightness_11++;// = v18;
-        if (x_D41A0_BYTEARRAY_4_struct.brightness_11 <= 4)
-          goto LABEL_86;
-        if (a3)
-        {
-          x_D41A0_BYTEARRAY_4_struct.brightness_11 = 4;
-          goto LABEL_86;
-        }
-      }
-      x_D41A0_BYTEARRAY_4_struct.brightness_11 = 0;
+			if (a2)
+			{
+				// v3 = x_D41A0_BYTEARRAY_4_struct.dwordindex_0;
+				// v19 = x_D41A0_BYTEARRAY_4[11] - 1;
+				x_D41A0_BYTEARRAY_4_struct.brightness_11--; // = v19;
+				if (x_D41A0_BYTEARRAY_4_struct.brightness_11 >= 0)
+					goto LABEL_86;
+				if (!a3)
+				{
+					x_D41A0_BYTEARRAY_4_struct.brightness_11 = 4;
+					goto LABEL_86;
+				}
+			}
+			else
+			{
+				// v3 = x_D41A0_BYTEARRAY_4_struct.dwordindex_0;
+				// v18 = x_D41A0_BYTEARRAY_4[11] + 1;
+				x_D41A0_BYTEARRAY_4_struct.brightness_11++; // = v18;
+				if (x_D41A0_BYTEARRAY_4_struct.brightness_11 <= 4)
+					goto LABEL_86;
+				if (a3)
+				{
+					x_D41A0_BYTEARRAY_4_struct.brightness_11 = 4;
+					goto LABEL_86;
+				}
+			}
+			x_D41A0_BYTEARRAY_4_struct.brightness_11 = 0;
 		LABEL_86:
-			sub_47650(a3/*, a2*/);
+			sub_47650(a3 /*, a2*/);
 			return;
 		}
 		if (v17 == MapType_t::Cave)
@@ -2729,87 +2729,87 @@ void sub_46B40()//227b40
 	int16_t v0_tempmousex = x_WORD_E3760_mouse.x;
 	int16_t v0_tempmousey = x_WORD_E3760_mouse.y;
 
-    sub_90B27_VGA_pal_fadein_fadeout(0, 0x10u, 0);
-    sub_417A0_install_pal_and_mouse_minmax();
-    memset((void*)*xadatapald0dat2.colorPalette_var28, 0, 768);
-    sub_41A90_VGA_Palette_install((TColor*)*xadatapald0dat2.colorPalette_var28);
+	sub_90B27_VGA_pal_fadein_fadeout(0, 0x10u, 0);
+	sub_417A0_install_pal_and_mouse_minmax();
+	memset((void*)*xadatapald0dat2.colorPalette_var28, 0, 768);
+	sub_41A90_VGA_Palette_install((TColor*)*xadatapald0dat2.colorPalette_var28);
 
-    if (pre_x_DWORD_E9C3C)
-    {
-        FreeMem_83E80(pre_x_DWORD_E9C3C);
-        pre_x_DWORD_E9C3C = 0;
-        x_DWORD_E9C3C = 0;
-    }
+	if (pre_x_DWORD_E9C3C)
+	{
+		FreeMem_83E80(pre_x_DWORD_E9C3C);
+		pre_x_DWORD_E9C3C = 0;
+		x_DWORD_E9C3C = 0;
+	}
 
-    sub_54600_mouse_reset();
+	sub_54600_mouse_reset();
 
-    sub_6EBF0(&filearray_2aa18c[filearrayindex_POINTERSDATTAB]);
-    sub_6EBF0(&filearray_2aa18c[filearrayindex_MSPRD00DATTAB]);
-    sub_6EBF0(&filearray_2aa18c[filearrayindex_BUILD00DATTAB]);
+	sub_6EBF0(&filearray_2aa18c[filearrayindex_POINTERSDATTAB]);
+	sub_6EBF0(&filearray_2aa18c[filearrayindex_MSPRD00DATTAB]);
+	sub_6EBF0(&filearray_2aa18c[filearrayindex_BUILD00DATTAB]);
 
-    sub_47130();
+	sub_47130();
 
-    //Change resolution
-    if (x_WORD_180660_VGA_type_resolution == 1)
-    {
-        sub_6EBF0(&filearray_2aa18c[filearrayindex_FONTS0DATTAB]);
-		DataFileIO::sub_90D3F_unload_file_array(psxadatamsprd00dat);
-        x_WORD_180660_VGA_type_resolution = 8;
-    }
-    else
-    {
-        sub_6EBF0(&filearray_2aa18c[filearrayindex_HFONT3DATTAB]);
-		DataFileIO::sub_90D3F_unload_file_array(psxadatahsprd00dat);
-        x_WORD_180660_VGA_type_resolution = 1;
-    }
-    sub_47160();
+	//Change resolution
+	if (x_WORD_180660_VGA_type_resolution == 1)
+	{
+		sub_6EBF0(&filearray_2aa18c[filearrayindex_FONTS0DATTAB]);
+		sub_90D3F_unload_file_array(psxadatamsprd00dat);
+		x_WORD_180660_VGA_type_resolution = 8;
+	}
+	else
+	{
+		sub_6EBF0(&filearray_2aa18c[filearrayindex_HFONT3DATTAB]);
+		sub_90D3F_unload_file_array(psxadatahsprd00dat);
+		x_WORD_180660_VGA_type_resolution = 1;
+	}
+	sub_47160();
 
-    CreateIndexes_6EB90(&filearray_2aa18c[filearrayindex_POINTERSDATTAB]);
-    CreateIndexes_6EB90(&filearray_2aa18c[filearrayindex_BUILD00DATTAB]);
+	CreateIndexes_6EB90(&filearray_2aa18c[filearrayindex_POINTERSDATTAB]);
+	CreateIndexes_6EB90(&filearray_2aa18c[filearrayindex_BUILD00DATTAB]);
 
-    memset((void*)*xadatapald0dat2.colorPalette_var28, 0, 768);
-    if (x_WORD_180660_VGA_type_resolution & 1)
-    {
-        v1 = getPaletteIndex_5BE80((TColor*)*xadatapald0dat2.colorPalette_var28, 0, 0, 0);
-        ClearGraphicsBuffer_72883((void*)pdwScreenBuffer_351628, 320, 200, v1);
-    }
-    else
-    {
-        v2 = getPaletteIndex_5BE80((TColor*)*xadatapald0dat2.colorPalette_var28, 0, 0, 0);
-        ClearGraphicsBuffer_72883((void*)pdwScreenBuffer_351628, screenWidth_18062C, screenHeight_180624, v2);
-    }
-    memset((void*)*xadatapald0dat2.colorPalette_var28, 0, 768);
-    sub_41A90_VGA_Palette_install((TColor*)*xadatapald0dat2.colorPalette_var28);
-    if (x_WORD_180660_VGA_type_resolution & 1)
-        sub_90D6E_VGA_set_video_mode_320x200_and_Palette((TColor*)*xadatapald0dat2.colorPalette_var28);
-    else
-    {
-        if (((gameResWidth > 640) || (gameResHeight > 480)) && (x_WORD_180660_VGA_type_resolution != 1))
-        {
-            screenWidth_18062C = gameResWidth;
-            screenHeight_180624 = gameResHeight;
-            sub_90E07_VGA_set_video_mode_alt_and_Palette((TColor*)*xadatapald0dat2.colorPalette_var28);
-        }
-        else
-            sub_90E07_VGA_set_video_mode_640x480_and_Palette((TColor*)*xadatapald0dat2.colorPalette_var28);
-    }
+	memset((void*)*xadatapald0dat2.colorPalette_var28, 0, 768);
+	if (x_WORD_180660_VGA_type_resolution & 1)
+	{
+		v1 = getPaletteIndex_5BE80((TColor*)*xadatapald0dat2.colorPalette_var28, 0, 0, 0);
+		ClearGraphicsBuffer_72883((void*)pdwScreenBuffer_351628, 320, 200, v1);
+	}
+	else
+	{
+		v2 = getPaletteIndex_5BE80((TColor*)*xadatapald0dat2.colorPalette_var28, 0, 0, 0);
+		ClearGraphicsBuffer_72883((void*)pdwScreenBuffer_351628, screenWidth_18062C, screenHeight_180624, v2);
+	}
+	memset((void*)*xadatapald0dat2.colorPalette_var28, 0, 768);
+	sub_41A90_VGA_Palette_install((TColor*)*xadatapald0dat2.colorPalette_var28);
+	if (x_WORD_180660_VGA_type_resolution & 1)
+		sub_90D6E_VGA_set_video_mode_320x200_and_Palette((TColor*)*xadatapald0dat2.colorPalette_var28);
+	else
+	{
+		if (((gameResWidth > 640) || (gameResHeight > 480)) && (x_WORD_180660_VGA_type_resolution != 1))
+		{
+			screenWidth_18062C = gameResWidth;
+			screenHeight_180624 = gameResHeight;
+			sub_90E07_VGA_set_video_mode_alt_and_Palette((TColor*)*xadatapald0dat2.colorPalette_var28);
+		}
+		else
+			sub_90E07_VGA_set_video_mode_640x480_and_Palette((TColor*)*xadatapald0dat2.colorPalette_var28);
+	}
 
-    sub_41A90_VGA_Palette_install((TColor*)*xadatapald0dat2.colorPalette_var28);
-    v3 = getPaletteIndex_5BE80((TColor*)*xadatapald0dat2.colorPalette_var28, 0, 0, 0);
-    uiBackGroundColorIdx_EB3A8 = v3;
-    if (x_WORD_180660_VGA_type_resolution & 1)
-        ClearGraphicsBuffer_72883((void*)pdwScreenBuffer_351628, 320, 200, v3);
-    else
-        ClearGraphicsBuffer_72883((void*)pdwScreenBuffer_351628, screenWidth_18062C, screenHeight_180624, v3);
+	sub_41A90_VGA_Palette_install((TColor*)*xadatapald0dat2.colorPalette_var28);
+	v3 = getPaletteIndex_5BE80((TColor*)*xadatapald0dat2.colorPalette_var28, 0, 0, 0);
+	uiBackGroundColorIdx_EB3A8 = v3;
+	if (x_WORD_180660_VGA_type_resolution & 1)
+		ClearGraphicsBuffer_72883((void*)pdwScreenBuffer_351628, 320, 200, v3);
+	else
+		ClearGraphicsBuffer_72883((void*)pdwScreenBuffer_351628, screenWidth_18062C, screenHeight_180624, v3);
 
-    sub_8CEDF_install_mouse();
-    sub_8CD27_set_cursor((*filearray_2aa18c[filearrayindex_POINTERSDATTAB].posistruct)[0]);
-    x_D41A0_BYTEARRAY_4_struct.byteindex_51 = 2;
-    if (x_WORD_180660_VGA_type_resolution == 1)
-        x_BYTE_D419D_fonttype = 1;
-    else
-        x_BYTE_D419D_fonttype = 3;
-    SetMousePositionInMemory_5BDC0(v0_tempmousex, v0_tempmousey);
+	sub_8CEDF_install_mouse();
+	sub_8CD27_set_cursor((*filearray_2aa18c[filearrayindex_POINTERSDATTAB].posistruct)[0]);
+	x_D41A0_BYTEARRAY_4_struct.byteindex_51 = 2;
+	if (x_WORD_180660_VGA_type_resolution == 1)
+		x_BYTE_D419D_fonttype = 1;
+	else
+		x_BYTE_D419D_fonttype = 3;
+	SetMousePositionInMemory_5BDC0(v0_tempmousex, v0_tempmousey);
 }
 
 //----- (00075C50) --------------------------------------------------------

--- a/remc2/engine/PlayerInput.cpp
+++ b/remc2/engine/PlayerInput.cpp
@@ -2753,13 +2753,13 @@ void sub_46B40()//227b40
 	if (x_WORD_180660_VGA_type_resolution == 1)
 	{
 		sub_6EBF0(&filearray_2aa18c[filearrayindex_FONTS0DATTAB]);
-		sub_90D3F_unload_file_array(psxadatamsprd00dat);
+		DataFileIO::sub_90D3F_unload_file_array(psxadatamsprd00dat);
 		x_WORD_180660_VGA_type_resolution = 8;
 	}
 	else
 	{
 		sub_6EBF0(&filearray_2aa18c[filearrayindex_HFONT3DATTAB]);
-		sub_90D3F_unload_file_array(psxadatahsprd00dat);
+		DataFileIO::sub_90D3F_unload_file_array(psxadatahsprd00dat);
 		x_WORD_180660_VGA_type_resolution = 1;
 	}
 	sub_47160();

--- a/remc2/engine/PlayerInput.cpp
+++ b/remc2/engine/PlayerInput.cpp
@@ -392,7 +392,7 @@ void sub_17190_process_keyboard()//1f8190
 				}
 				if (pressedKeys_180664[24])
 				{
-					D41A0_0.byte_0x36E04 = 2;
+					D41A0_0.byte_counter_current_objective_box_0x36E04 = 2;
 				}
 				return;
 			}
@@ -421,7 +421,7 @@ void sub_18BB0()//1f9bb0
 		}
 		else
 		{
-			D41A0_0.byte_0x36E04 = 0;
+			D41A0_0.byte_counter_current_objective_box_0x36E04 = 0;
 			v2 = x_D41A0_BYTEARRAY_4_struct.byteindex_206;
 			str_unk_1804B0ar.byte_0xaa = -1;
 			if (!v2 && (unk_18058Cstr.x_WORD_1805C2_joystick == 7 || unk_18058Cstr.x_WORD_1805C2_joystick == 1 || unk_18058Cstr.x_WORD_1805C2_joystick == 2))

--- a/remc2/engine/Sound.cpp
+++ b/remc2/engine/Sound.cpp
@@ -5835,7 +5835,7 @@ void ChangeSoundLevel_19CA0(uint8_t option)//1faca0
 	}
 	if (x_D41A0_BYTEARRAY_4_struct.byte_38591)
 	{
-		D41A0_0.byte_0x36E04 = 0;
+		D41A0_0.byte_counter_current_objective_box_0x36E04 = 0;
 		x_D41A0_BYTEARRAY_4_struct.setting_38402 = 1;
 		if (D41A0_0.array_0x2BDE[D41A0_0.LevelIndex_0xc].byte_0x3DF_2BE4_12221 < 6u || D41A0_0.array_0x2BDE[D41A0_0.LevelIndex_0xc].byte_0x3DF_2BE4_12221 > 8u)
 			HandleButtonClick_191B0(20, 10);

--- a/remc2/engine/engine_support.cpp
+++ b/remc2/engine/engine_support.cpp
@@ -936,6 +936,11 @@ uint32_t compare_with_sequence_D41A0(const char* filename, uint8_t* adress, uint
 			{
 				*origbyte = buffer[i];
 				*copybyte = adress[i];
+				for (int j = 0; (j < 10) && (i+j < size); j++)
+				{
+					std::cout << "buffer[" << i + j << "] = " << (int)buffer[i + j] << "   ";
+					std::cout << "adress[" << i + j << "] = " << (int)adress[i + j] << std::endl;
+				}
 				break;
 			}
 		}

--- a/remc2/engine/engine_support.cpp
+++ b/remc2/engine/engine_support.cpp
@@ -676,6 +676,7 @@ int test_D41A0_id_pointer(uint32_t adress) {
 	if ((adress >= 0x2fc4) && (adress < 0x2fc5))return 2;//event
 
 	if ((adress >= 0x2fd8) && (adress < 0x2fdc))return 2; // mouse position: position_backup_20 in dword_0x3E6_2BE4_12228 in array_0x2BDE
+	// if ((adress == 0x36e04))return 2;                     // objective box counter
 
 	if ((adress >= 0x314d) && (adress < 0x3151))return 2;//clock - 4 bytes
 	if ((adress >= 0x3999) && (adress < 0x399d))return 2;//clock2 - 4 bytes
@@ -942,6 +943,12 @@ uint32_t compare_with_sequence_D41A0(const char* filename, uint8_t* adress, uint
 
 	if (i < size) {
 		Logger->error("Regression compare sequence error @ function {}, line {}, byte: {}",__FUNCTION__ , __LINE__, i);
+		// print the next 10 bytes of buffer and adress
+		for (int j = 0; (j < 10) && (i+j < size); j++)
+		{
+			std::cout << "buffer[" << i + j << "] = " << (int)buffer[i + j] << "   ";
+			std::cout << "adress[" << i + j << "] = " << (int)adress[i + j] << std::endl;
+		}
 		End_thread(-1);
 	}
 	free(buffer);

--- a/remc2/engine/engine_support.h
+++ b/remc2/engine/engine_support.h
@@ -1241,7 +1241,7 @@ typedef struct {//lenght 224791
 	uint8_t stageIndex_0x36E01;//count objectives
 	int8_t byte_0x36E02;//temp objective
 	int8_t byte_0x36E03;
-	int8_t byte_0x36E04;
+	uint8_t byte_counter_current_objective_box_0x36E04;
 	uint8_t stub3k[6];
 	int8_t byte_0x36E0B;
 	uint8_t stubend[11];
@@ -1400,7 +1400,7 @@ typedef struct {//lenght 224791
 	uint8_t byte_0x36E01;
 	int8_t byte_0x36E02;
 	int8_t byte_0x36E03;
-	int8_t byte_0x36E04;
+	uint8_t byte_counter_current_objective_box_0x36E04;
 	uint8_t stub3k[6];
 	int8_t byte_0x36E0B;
 	uint8_t stubend[11];

--- a/remc2/engine/engine_support_converts.cpp
+++ b/remc2/engine/engine_support_converts.cpp
@@ -806,8 +806,8 @@ void convert_struct_to_array_D41A0_0(type_D41A0_BYTESTR_0* input,uint8_t* output
 	memcpy(output + 0x36E02, &input->byte_0x36E02, 1);
 	//int8_t byte_0x36E03;
 	memcpy(output + 0x36E03, &input->byte_0x36E03, 1);
-	//int8_t byte_0x36E04;
-	memcpy(output + 0x36E04, &input->byte_0x36E04, 1);
+	//uint8_t byte_counter_current_objective_box_0x36E04;
+	memcpy(output + 0x36E04, &input->byte_counter_current_objective_box_0x36E04, 1);
 	//uint8_t stub3k[6];
 	memset(output + 0x36E05, 0, 6);
 	//int8_t byte_0x36E0B;

--- a/remc2/sub_main.cpp
+++ b/remc2/sub_main.cpp
@@ -22343,7 +22343,7 @@ void DrawGameFrame_2BE30()//20CE30
 			help_ScreenBuffer = nullptr;
 		} 
 	}
-	if (D41A0_0.byte_0x36E04)
+	if (D41A0_0.byte_counter_current_objective_box_0x36E04)
 		DrawCurrentObjectiveTextbox_30630(scale);
 	GetFont_6FC50(x_BYTE_D419D_fonttype);
 	if (!(x_D41A0_BYTEARRAY_4_struct.setting_byte1_22 & 4))
@@ -43006,9 +43006,9 @@ void sub_59820()//23a820
 	char v10; // cl
 	int v11; // ebx
 
-	if (D41A0_0.byte_0x36E04)
+	if (D41A0_0.byte_counter_current_objective_box_0x36E04)
 	{
-		if (D41A0_0.byte_0x36E04-- == 1)
+		if (D41A0_0.byte_counter_current_objective_box_0x36E04-- == 1)
 			sub_88BA0();
 	}
 	if (x_D41A0_BYTEARRAY_4_struct.setting_38545 & 0x40 && sub_86180(x_WORD_1803EC) == 256)
@@ -43090,7 +43090,7 @@ void sub_59820()//23a820
 			}
 			D41A0_0.byte_0x36E02 = 0;
 			v10 = D41A0_0.byte_0x36E0B;
-			D41A0_0.byte_0x36E04 = -56;
+			D41A0_0.byte_counter_current_objective_box_0x36E04 = 200; // set counter for displaying objective message box to 200
 			if (v10 & 1)
 			{
 			LABEL_36:
@@ -51102,7 +51102,7 @@ void sub_872A0()//2682a0
 	if (v2x->state_0x45_69 == 3)
 		str_unk_1804B0ar.byte_0x9f = str_unk_1804B0ar.byte_0x9f | 4;
 	str_unk_1804B0ar.PopupStatusByte_0x9e &= 0xEF;
-	if (D41A0_0.byte_0x36E04
+	if (D41A0_0.byte_counter_current_objective_box_0x36E04
 		|| x_D41A0_BYTEARRAY_4_struct.byteindex_225
 		|| v2x->state_0x45_69 == 12
 		|| v2x->state_0x45_69 == 11

--- a/remc2/utilities/StateMonitor.cpp
+++ b/remc2/utilities/StateMonitor.cpp
@@ -224,7 +224,7 @@ void StateMonitor::MonitorD41A0() {
     MONITOR_STRUCT_VARIABLE_HEX(D41A0_0, stageIndex_0x36E01);
     MONITOR_STRUCT_VARIABLE_HEX(D41A0_0, byte_0x36E02);
     MONITOR_STRUCT_VARIABLE_HEX(D41A0_0, byte_0x36E03);
-    MONITOR_STRUCT_VARIABLE_HEX(D41A0_0, byte_0x36E04);
+    MONITOR_STRUCT_VARIABLE_HEX(D41A0_0, byte_counter_current_objective_box_0x36E04);
 	// uint8_t stub3k[6];
     MONITOR_STRUCT_VARIABLE_HEX(D41A0_0, byte_0x36E0B);
 	// uint8_t stubend[11];


### PR DESCRIPTION
There is a difference in all the tests in 4 bytes which belong to a mouse position in position_backup_20 in dword_0x3E6_2BE4_12228 in array_0x2BDE.
Also renamed the counter for the in-game objective message box and converted the counter to uint8_t.