### PR TITLE
Add macOS (Apple Silicon) build support

### DIFF
--- a/remc2-editor/CMakeLists.txt
+++ b/remc2-editor/CMakeLists.txt
@@ -174,6 +174,15 @@ target_include_directories(${EDITOR_TARGET} PUBLIC
     "../findfirst"
     "../spdlog/include"
 )
+if (APPLE)
+    execute_process(COMMAND brew --prefix
+        OUTPUT_VARIABLE HOMEBREW_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    target_include_directories(${EDITOR_TARGET} PUBLIC
+        "${HOMEBREW_PREFIX}/include"
+    )
+    target_include_directories(${EDITOR_TARGET} PUBLIC ${PNG_INCLUDE_DIRS})
+endif ()
 add_compile_definitions(COMPILE_FOR_64BIT)
 
 install(

--- a/remc2-editor/ReadConfig.cpp
+++ b/remc2-editor/ReadConfig.cpp
@@ -7,7 +7,7 @@ std::string ReadConfig::FindConfigFile() {
 		configFile_locations.push_back(CommandLineParams.GetConfigFilePath());
 	}
 	else {
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		auto env_home_dir = std::getenv("HOME");
 		auto env_xdg_config_home_dir = std::getenv("XDG_CONFIG_HOME");
 		std::filesystem::path home_dir;

--- a/remc2/CMakeLists.txt
+++ b/remc2/CMakeLists.txt
@@ -255,6 +255,15 @@ if (UNIX)
         "${CMAKE_SOURCE_DIR}/spdlog/include"
         "${CMAKE_SOURCE_DIR}/rapidjson"
     )
+    if (APPLE)
+        execute_process(COMMAND brew --prefix
+            OUTPUT_VARIABLE HOMEBREW_PREFIX
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        target_include_directories(${PROJECT_NAME} PUBLIC
+            "${HOMEBREW_PREFIX}/include"
+        )
+        target_include_directories(${PROJECT_NAME} PUBLIC ${PNG_INCLUDE_DIRS})
+    endif ()
     #target_compile_definitions(${PROJECT_NAME} PRIVATE
     #)
     #target_compile_options(${PROJECT_NAME} PRIVATE

--- a/remc2/engine/Events.cpp
+++ b/remc2/engine/Events.cpp
@@ -796,7 +796,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x1f6d40: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		sub_15D40((short)a1_6E8E, 0, 0);
@@ -890,7 +890,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x1fa1b0: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		HandleButtonClick_191B0((short)a1_6E8E, 0);
@@ -916,7 +916,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x1faca0: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		ChangeSoundLevel_19CA0((uint8_t)a1_6E8E);
@@ -979,7 +979,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x1fb970: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		ChangeSettings_1A970((intptr_t)a1_6E8E, 0, 0);
@@ -2257,7 +2257,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x20cc80: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		DrawLine_2BC80((uint16_t)a1_6E8E, 0, 0, 0, 0);
@@ -2522,7 +2522,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 	}
 
 	case 0x215b00: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		sub_34B00((intptr_t)a1_6E8E, 0, 0, 0);
@@ -2776,7 +2776,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x233d70: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		ShowMessage_52D70((unsigned short)a1_6E8E, 0);
@@ -2798,7 +2798,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x2343b0: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		LevelDecompress_533B0((short)a1_6E8E, 0);
@@ -2943,7 +2943,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x241400: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
         allert_error();
 #else
@@ -3781,7 +3781,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x24e420: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		SelectSpellCategory_6D420((short)a1_6E8E, 0);
@@ -3816,7 +3816,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 	}
 
 	case 0x24e8b0: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
         allert_error();
 #else
@@ -3834,7 +3834,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x24eb50: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		sub_6DB50((char)a1_6E8E, 0);
@@ -3848,7 +3848,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 	}
 
 	case 0x24ec40: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		sub_6DC40_improve_ability((unsigned char)a1_6E8E);
@@ -3861,7 +3861,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x24f020: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		GetSpellIndex_6E020((unsigned short)a1_6E8E);
@@ -3883,7 +3883,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x24f450: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		PrepareEventSound_6E450((short)a1_6E8E, 0, 0);
@@ -3929,7 +3929,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x24fde0: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		SetMousePosition_6EDE0((intptr_t)a1_6E8E, 0);
@@ -3938,7 +3938,7 @@ void pre_sub_4A190_0x6E8E(uint32_t adress, type_entity_0x6E8E* a1_6E8E)//pre 22b
 		break;
 	}
 	case 0x24ff10: {
-#ifdef __linux__ // FIXME: types
+#if defined(__linux__) || defined(__APPLE__) // FIXME: types
 		std::cout << "FIXME: types @ function " << __FUNCTION__ << ", line " << __LINE__ << std::endl;
 #else
 		sub_6EF10_set_mouse_minmax((intptr_t)a1_6E8E, 0, 0, 0);

--- a/remc2/engine/EventsFunctions.cpp
+++ b/remc2/engine/EventsFunctions.cpp
@@ -22,7 +22,7 @@
 #include "Type_DB080_CdTrack.h"
 
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <strings.h>
 #include <cstdlib>
 #include <cstring>

--- a/remc2/engine/MenusAndIntros.cpp
+++ b/remc2/engine/MenusAndIntros.cpp
@@ -14,7 +14,7 @@ int16_t MOUSE_MIN = 0;
 int16_t MOUSE_MAX_X = 638;
 int16_t MOUSE_MAX_Y = 478;
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 void _strupr(char* s)
 {
 	char* p = s;

--- a/remc2/engine/defs.h
+++ b/remc2/engine/defs.h
@@ -9,7 +9,7 @@
 
 */
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #define _stricmp strcasecmp
 #define _strnicmp strncasecmp
 #define strnicmp strncasecmp

--- a/remc2/engine/engine_support.cpp
+++ b/remc2/engine/engine_support.cpp
@@ -1856,7 +1856,7 @@ uint32_t compare_with_sequence(const char* filename, const uint8_t* adress, uint
 		fptestepc = fopen(findname.c_str(), "rb");
 	}
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 	fseek(fptestepc, (long long)count * (long long)size1 + offset, SEEK_SET);
 #else
 	_fseeki64(fptestepc, (long long)count * (long long)size1 + offset, SEEK_SET);

--- a/remc2/engine/read_config.cpp
+++ b/remc2/engine/read_config.cpp
@@ -62,7 +62,7 @@ std::string findConfigFile() {
 		config_locations.push_back(CommandLineParams.GetConfigFilePath());
 	}
 	else {
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		auto env_home_dir = std::getenv("HOME");
 		auto env_xdg_config_home_dir = std::getenv("XDG_CONFIG_HOME");
 		std::filesystem::path home_dir;

--- a/remc2/portability/Config.cpp
+++ b/remc2/portability/Config.cpp
@@ -72,7 +72,7 @@ void Config::LoadSettings(rapidjson::Document& document)
 
 	for (int i = 0; i < settingsArray.Size(); i++)
 	{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		auto settings = settingsArray[i].GetObject();
 #else
 		auto settings = settingsArray[i].GetObj();
@@ -95,7 +95,7 @@ void Config::LoadGame(rapidjson::GenericObject<false, rapidjson::Value>& setting
 {
 	if (settings.HasMember("game"))
 	{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		auto game = settings["game"].GetObject();
 #else
 		auto game = settings["game"].GetObj();
@@ -109,7 +109,7 @@ void Config::LoadControls(rapidjson::GenericObject<false, rapidjson::Value>& set
 {
 	if (settings.HasMember("controls"))
 	{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		auto controls = settings["controls"].GetObject();
 #else
 		auto controls = settings["controls"].GetObj();
@@ -121,7 +121,7 @@ void Config::LoadControls(rapidjson::GenericObject<false, rapidjson::Value>& set
 
 			for (int i = 0; i < mouseArray.Size(); i++)
 			{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 				auto mouse = mouseArray[i].GetObject();
 #else
 				auto mouse = mouseArray[i].GetObj();
@@ -149,7 +149,7 @@ void Config::LoadControls(rapidjson::GenericObject<false, rapidjson::Value>& set
 
 			for (int i = 0; i < keyboardArray.Size(); i++)
 			{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 				auto keyboard = keyboardArray[i].GetObject();
 #else
 				auto keyboard = keyboardArray[i].GetObj();
@@ -174,7 +174,7 @@ void Config::LoadControls(rapidjson::GenericObject<false, rapidjson::Value>& set
 
 			for (int i = 0; i < gamePadArray.Size(); i++)
 			{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 				auto gamePad = gamePadArray[i].GetObject();
 #else
 				auto gamePad = gamePadArray[i].GetObj();
@@ -216,7 +216,7 @@ void Config::LoadControls(rapidjson::GenericObject<false, rapidjson::Value>& set
 
 					if (gamePad.HasMember("axisYawSensitivity"))
 					{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 						auto axisYawSensitivity = gamePad["axisYawSensitivity"].GetObject();
 #else
 						auto axisYawSensitivity = gamePad["axisYawSensitivity"].GetObj();
@@ -227,7 +227,7 @@ void Config::LoadControls(rapidjson::GenericObject<false, rapidjson::Value>& set
 
 							for (int z = 0; z < zonesArray.Size(); z++) // Uses SizeType instead of size_t
 							{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 								auto zone = zonesArray[z].GetObject();
 #else
 								auto zone = zonesArray[z].GetObj();
@@ -246,7 +246,7 @@ void Config::LoadControls(rapidjson::GenericObject<false, rapidjson::Value>& set
 
 					if (gamePad.HasMember("axisPitchSensitivity"))
 					{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 						auto axisPitchSensitivity = gamePad["axisPitchSensitivity"].GetObject();
 #else
 						auto axisPitchSensitivity = gamePad["axisPitchSensitivity"].GetObj();
@@ -257,7 +257,7 @@ void Config::LoadControls(rapidjson::GenericObject<false, rapidjson::Value>& set
 
 							for (int z = 0; z < zonesArray.Size(); z++) // Uses SizeType instead of size_t
 							{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 								auto zone = zonesArray[z].GetObject();
 #else
 								auto zone = zonesArray[z].GetObj();
@@ -280,7 +280,7 @@ void Config::LoadGraphics(rapidjson::GenericObject<false, rapidjson::Value>& set
 {
 	if (settings.HasMember("graphics"))
 	{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		auto graphics = settings["graphics"].GetObject();
 #else
 		auto graphics = settings["graphics"].GetObj();
@@ -300,7 +300,7 @@ void Config::LoadGameDetail(rapidjson::GenericObject<false, rapidjson::Value>& g
 {
 	if (graphics.HasMember("gameDetail"))
 	{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		auto gameDetail = graphics["gameDetail"].GetObject();
 #else
 		auto gameDetail = graphics["gameDetail"].GetObj();
@@ -320,7 +320,7 @@ void Config::LoadGameDetail(rapidjson::GenericObject<false, rapidjson::Value>& g
 
 void Config::LoadThreading(rapidjson::GenericObject<false, rapidjson::Value>& graphics)
 {
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 	auto threading = graphics["threading"].GetObject();
 #else
 	auto threading = graphics["threading"].GetObj();
@@ -340,7 +340,7 @@ void Config::LoadSound(rapidjson::GenericObject<false, rapidjson::Value>& settin
 {
 	if (settings.HasMember("sound"))
 	{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		auto sound = settings["sound"].GetObject();
 #else
 		auto sound = settings["sound"].GetObj();
@@ -360,7 +360,7 @@ void Config::LoadPaths(rapidjson::GenericObject<false, rapidjson::Value>& settin
 {
 	if (settings.HasMember("paths"))
 	{
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		auto paths = settings["paths"].GetObject();
 #else
 		auto paths = settings["paths"].GetObj();

--- a/remc2/portability/fcaseopen.cpp
+++ b/remc2/portability/fcaseopen.cpp
@@ -9,7 +9,7 @@ static bool our_iequals(const std::string& a, const std::string& b) {
 	return true;
 }
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <stdlib.h>
 #include <string.h>
 
@@ -94,7 +94,7 @@ std::string casepath(const std::string &path)
 FILE* fcaseopen(char const* path, char const* mode)
 {
     FILE* f = fopen(path, mode);
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     if (!f)
     {
         std::string r = casepath(path);

--- a/remc2/portability/port_filesystem.cpp
+++ b/remc2/portability/port_filesystem.cpp
@@ -27,6 +27,12 @@ spdlog::logger* Logger = nullptr;
     #include <cstdio>
 #endif
 
+#ifdef __APPLE__
+	#include <mach-o/dyld.h>
+	#include <stdlib.h>
+	#include <climits>
+#endif
+
 const char* GetStringFromLoggingLevel(spdlog::level::level_enum level)
 {
 	const char* level_enum_str[] = { "Trace", "Debug", "Info", "Warn", "Err", "Critical" };
@@ -111,6 +117,19 @@ std::string get_exe_path() {
 	delete[] buffer;
 	std::string::size_type pos = std::string(locstr).find_last_of("\\/");
 	std::string strpathx = std::string(locstr).substr(0, pos)/*+"\\system.exe"*/;
+	return strpathx;
+#elif defined(__APPLE__)
+	std::string strpathx;
+	char result[PATH_MAX];
+	uint32_t size = sizeof(result);
+	if (_NSGetExecutablePath(result, &size) == 0) {
+		char real[PATH_MAX];
+		if (realpath(result, real)) {
+			strpathx = dirname(real);
+		} else {
+			strpathx = dirname(result);
+		}
+	}
 	return strpathx;
 #else
 	std::string strpathx;
@@ -448,7 +467,7 @@ long ReadGraphicsfile(const char* path, uint8_t* buffer, long size)
 std::string getExistingDataPath(std::filesystem::path path) 
 {
 	std::vector<std::string> file_locations;
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 	auto env_home_dir = std::getenv("HOME");
 	auto env_xdg_data_home_dir = std::getenv("XDG_DATA_HOME");
 	std::filesystem::path home_dir;
@@ -478,7 +497,7 @@ std::string getExistingDataPath(std::filesystem::path path)
 
 	// first location at which the file can be found is chosen
 	for (const std::string &file_location: file_locations) {
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 		std::string caseInsensitivePath = casepath(file_location);
 		if (std::filesystem::exists(caseInsensitivePath)) {
 			file_found = std::string(caseInsensitivePath);

--- a/remc2/portability/port_sdl_sound.cpp
+++ b/remc2/portability/port_sdl_sound.cpp
@@ -4,7 +4,7 @@
 #include <adlmidi.h>
 #include <iostream>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     #include <limits>
     #define MAX_PATH PATH_MAX
 #endif

--- a/remc2/sub_main.cpp
+++ b/remc2/sub_main.cpp
@@ -33,7 +33,7 @@ after NetworkCancel_748F7 not changed
 
 */
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <strings.h>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
## Summary

The project currently builds on Windows + Linux. This PR makes it possible to **configure and compile** the engine on macOS (tested on Apple Silicon, macOS 26). It does **not** yet produce a working binary on its own — there is one remaining linker issue specific to arm64 fixup-chain relocations, addressed in a follow-up PR ([macos-arm64-alignment-workaround](https://github.com/asnaedae/magic-carpet-2-hd/tree/macos-arm64-alignment-workaround)) so the discussion-worthy linker workaround stays separate from these straightforward portability changes.

## Changes

### CMake
- `remc2/CMakeLists.txt`, `remc2-editor/CMakeLists.txt`: when `APPLE`, run `brew --prefix` and add `\${HOMEBREW_PREFIX}/include` plus `\${PNG_INCLUDE_DIRS}` to the target include directories.

  The project assumes `spdlog` and `rapidjson` headers are reachable either via `\${CMAKE_SOURCE_DIR}/spdlog/include` / `\${CMAKE_SOURCE_DIR}/rapidjson` or via the default system include path the way Debian's `-dev` packages provide. On macOS Apple Silicon, Homebrew installs to `/opt/homebrew/include`, which is **not** on clang's default search path, so neither header is found without this change.

### \`__linux__\` → \`__linux__ || __APPLE__\`
The codebase uses \`#ifdef __linux__\` as an idiomatic 'not Windows' marker in ~30 sites across 12 files — both for portability shims (\`#define _stricmp strcasecmp\`, \`__cdecl\`, etc.) and for the FIXME-types stub branches around RE'd dispatch code that doesn't compile on 64-bit. Extending each of these guards to \`#if defined(__linux__) || defined(__APPLE__)\` is a no-op on Linux and Windows, and lets macOS take the same code paths as Linux.

Files touched: \`engine/defs.h\`, \`engine/Events.cpp\`, \`engine/EventsFunctions.cpp\`, \`engine/MenusAndIntros.cpp\`, \`engine/read_config.cpp\`, \`engine/engine_support.cpp\`, \`sub_main.cpp\`, \`portability/Config.cpp\`, \`portability/fcaseopen.cpp\`, \`portability/port_filesystem.cpp\`, \`portability/port_sdl_sound.cpp\`, \`remc2-editor/ReadConfig.cpp\`.

### \`_strupr\` shim
\`engine/defs.h\`: add a 4-line inline \`_strupr()\` under the same Unix guard. There's no POSIX equivalent, and \`_stricmp\`/\`_strnicmp\` already had \`#define\` shims that the guard extension above re-enables for macOS.

### \`get_exe_path()\` for macOS
\`portability/port_filesystem.cpp\`: \`get_exe_path()\` previously called \`readlink(\"/proc/self/exe\")\`, which doesn't exist on macOS. Add an \`__APPLE__\` branch that uses \`_NSGetExecutablePath()\` + \`realpath()\` from \`<mach-o/dyld.h>\`. Without this, the engine can't resolve the directory containing its own binary, so it can't find \`config.json\` next to itself and exits at startup with \"Config.json not found!\".

## What this gets you

After this change the engine **compiles and links almost cleanly** on macOS. There are some \`pointer not aligned\` linker errors related to 64-bit pointers stored in \`#pragma pack(1)\` structs, which arm64's default fixup-chain relocations reject. That is a separate, more discussable change — see [macos-arm64-alignment-workaround](https://github.com/asnaedae/magic-carpet-2-hd/tree/macos-arm64-alignment-workaround), opened as a follow-up PR.

With both PRs applied, I've verified end-to-end on Apple Silicon:
- Native arm64 Mach-O \`remc2\` built
- Engine reaches *\"Original Game Data Found! Copyright (c) 1995 Bullfrog Productions Ltd. Magic Carpet 2 (Netherworlds)\"*
- All NETHERW subdirs accessible, \`SOUND/DIG.INI\`/\`SOUND/MDI.INI\` loaded, asset load 0%→100%, music-ogg track search begins.

## Test plan

- [ ] \`brew install sdl2 sdl2_mixer sdl2_image sdl2_ttf spdlog rapidjson fmt p7zip bchunk\`
- [ ] \`git submodule update --init\` (for \`findfirst\`)
- [ ] \`mkdir -p build/Debug && cd build/Debug && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=./inst ../.. && make -j\$(sysctl -n hw.ncpu)\`
- [ ] Compile completes; link fails with \`pointer not aligned\` (expected — see PR 2)
- [ ] After also applying #PR2, link succeeds and the engine runs against an MC2 install
- [ ] Existing Windows + Linux CI is unaffected (every change is gated on \`APPLE\` or \`defined(__APPLE__)\`)