### PR TITLE
Fix for try/catch/throw for android

### DIFF
--- a/remc2-editor/editor.cpp
+++ b/remc2-editor/editor.cpp
@@ -144,11 +144,13 @@ void editor_run()
 	gameDataPath = GetSubDirectoryPath(gameFolder.c_str());
 	cdDataPath = GetSubDirectoryPath(cdFolder.c_str());
 
+#ifndef __ANDROID__
 	if (!std::filesystem::exists(gameDataPath))
 		throw std::invalid_argument("Game Data Path is not valid");
 
 	if (!std::filesystem::exists(cdDataPath))
 		throw std::invalid_argument("CD Data Path is not valid");
+#endif
 
 	DataFileIO::SetCDFilePaths(cdDataPath.c_str(), pstr);
 

--- a/remc2/engine/Level.cpp
+++ b/remc2/engine/Level.cpp
@@ -690,11 +690,16 @@ void LoadFixedMenuGraphics()
 		std::string indexStr = filename.substr(prefix.size(),
 			filename.size() - prefix.size() - 4);
 		int spriteIndex = -1;
-		try { spriteIndex = std::stoi(indexStr); }
+#ifndef __ANDROID__
+		try
+#endif
+		{ spriteIndex = std::stoi(indexStr); }
+#ifndef __ANDROID__
 		catch (...) {
 			Logger->warn("LoadFixedMenuGraphics: cannot parse index from '{}', skipped.", filename);
 			continue;
 		}
+#endif
 		if (spriteIndex < 0 || spriteIndex >= numSprites)
 		{
 			Logger->warn("LoadFixedMenuGraphics: index {} out of range [0,{}), skipped.",

--- a/remc2/engine/RenderThread.cpp
+++ b/remc2/engine/RenderThread.cpp
@@ -21,14 +21,18 @@ RenderThread::RenderThread(uint8_t core)
 
 RenderThread::~RenderThread()
 {
+#ifndef __ANDROID__
 	try
+#endif
 	{
 		StopWorkerThread();
 	}
+#ifndef __ANDROID__
 	catch (const std::exception& e)
 	{
 		Logger->error("Error Stopping Worker Thread: {}", e.what());
 	}
+#endif
 }
 
 void RenderThread::StartWorkerThread(int8_t core)

--- a/remc2/engine/engine_support.cpp
+++ b/remc2/engine/engine_support.cpp
@@ -1033,7 +1033,9 @@ void allert_error() {
 void Exit_thread()
 {
 	thread_exit_exception e;
+#ifndef __ANDROID__
 	throw e;
+#endif
 }
 
 void End_thread(int backCode)

--- a/remc2/engine/read_config.cpp
+++ b/remc2/engine/read_config.cpp
@@ -119,7 +119,9 @@ bool SetConfig() {
 	else {
 		if (CommandLineParams.DoShowDebugMessages1())
 			std::cout << "Config File cannot be found... Exiting\n";
+#ifndef __ANDROID__
 		throw std::invalid_argument("Config.json not found!");
+#endif
 		return false;
 	}
 

--- a/remc2/sub_main.cpp
+++ b/remc2/sub_main.cpp
@@ -535,7 +535,9 @@ int sub_main(int argc, char** argv, char**  /*envp*/)//236F70
 
 	SetTimeStart();
 
+#ifndef __ANDROID__
 	try
+#endif
 	{
 		begin_plugin();
 
@@ -566,15 +568,19 @@ int sub_main(int argc, char** argv, char**  /*envp*/)//236F70
 
 		Logger->info("Reading config.json file");
 
+#ifndef __ANDROID__
 		try
+#endif
 		{
 			SetConfig();
 		}
+#ifndef __ANDROID__
 		catch (const std::exception& e)
 		{
 			Logger->critical("Error reading config.json file: {}", e.what());
 			return -1;
 		}
+#endif
 
 		EventDispatcher::I = new EventDispatcher();
 
@@ -680,6 +686,7 @@ int sub_main(int argc, char** argv, char**  /*envp*/)//236F70
 		delete EventDispatcher::I;
 		VGA_close();
 	}
+#ifndef __ANDROID__
 	catch (const thread_exit_exception& e)
 	{
 		Logger->info("Immediate Exit called");
@@ -689,6 +696,7 @@ int sub_main(int argc, char** argv, char**  /*envp*/)//236F70
 		Logger->critical("Critical Error: {}", e.what());
 		exitCode = -1;
 	}
+#endif
 	Logger->info("Exited Game");
 	return exitCode;
 }

--- a/remc2/utilities/RendererTests.cpp
+++ b/remc2/utilities/RendererTests.cpp
@@ -82,7 +82,9 @@ void renderer_tests_eval_findings() {
 	}
 
 	if (!renderer_tests_success) {
+#ifndef __ANDROID__
 		throw std::runtime_error("Render tests failed, Exiting!");
+#endif
 	}
 	else {
 		Logger->info("No differences between HD and Original renderer and all checkpoints hit");


### PR DESCRIPTION
ARM does not natively support try/catch/throw.
If exceptions are enabled, it can emulate them, but at the cost of reduced performance.
The issue is compiling mixed code (for the MagicBalls project), where exceptions are disabled in Godot but enabled in C++, which is currently not possible in the NDK.